### PR TITLE
feat(ego-simulate): add ESLint errors as rejection reason #23

### DIFF
--- a/skills/ego-simulate/SKILL.md
+++ b/skills/ego-simulate/SKILL.md
@@ -3,7 +3,7 @@ name: ego-simulate
 description: >-
   Simulate an EGO review submission — produces a readiness report based on
   published review criteria. Triages the extension in reviewer order, applies
-  a 22-reason rejection taxonomy with weighted scoring, and generates a
+  a 23-reason rejection taxonomy with weighted scoring, and generates a
   structured report with a pass/fail verdict. Use before EGO submission to
   assess review readiness.
 ---
@@ -63,7 +63,7 @@ monologue style: "I see X but Y is missing" or "This looks clean."
 
 Read `references/rejection-taxonomy.md` before scoring.
 
-Apply the 22-reason rejection taxonomy. For each reason:
+Apply the 23-reason rejection taxonomy. For each reason:
 - Check whether the extension triggers it
 - If triggered, record the weight and the specific evidence (file:line)
 - Each reason contributes its weight ONCE regardless of occurrence count
@@ -112,7 +112,7 @@ monologue. What did they notice first? What's their gut feeling?]
 
 Read these reference documents before generating the report:
 - `references/reviewer-persona.md` — How reviewers triage submissions
-- `references/rejection-taxonomy.md` — 22 rejection reasons with weights
+- `references/rejection-taxonomy.md` — 23 rejection reasons with weights
 - `references/approved-examples.md` — Idiomatic patterns reviewers like
 
 ## Important

--- a/skills/ego-simulate/references/rejection-taxonomy.md
+++ b/skills/ego-simulate/references/rejection-taxonomy.md
@@ -1,6 +1,6 @@
 # EGO Rejection Taxonomy
 
-22 common rejection reasons weighted by severity. Use these weights to compute
+23 common rejection reasons weighted by severity. Use these weights to compute
 a simulation score.
 
 ## Weight 10 — Hard Blockers (automatic rejection)
@@ -34,6 +34,7 @@ a simulation score.
 | 15 | Import segregation | GTK in `extension.js` or Shell modules in `prefs.js` |
 | 16 | InjectionManager leak | `new InjectionManager()` without `.clear()` in disable |
 | 17 | Mock/test code shipped | `MockDevice.js`, test files in production package |
+| 23 | ESLint errors | Code that fails ESLint with errors (undefined references, syntax errors, missing imports) |
 
 ## Weight 3 — Style/Quality
 
@@ -67,3 +68,5 @@ a simulation score.
   the rejection threshold
 - Hard blockers are independently sufficient for rejection
 - When multiple reasons in the same weight class trigger, sum all their weights
+- ego-lint runs ESLint as part of its automated checks. If ESLint reports
+  errors (not warnings), reason #23 is triggered with weight 5.


### PR DESCRIPTION
## Summary
- Adds reason #23 (ESLint errors) to the rejection taxonomy at weight 5 (Structural Issues)
- Updates SKILL.md references from 22-reason to 23-reason taxonomy
- Adds scoring note linking reason #23 to ego-lint's existing ESLint check

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)