### PR TITLE
feat(ego-simulate): integrate ego-lint FAIL results into taxonomy scoring

### DIFF
--- a/skills/ego-simulate/SKILL.md
+++ b/skills/ego-simulate/SKILL.md
@@ -70,6 +70,20 @@ Apply the 23-reason rejection taxonomy. For each reason:
 
 Sum the weights to compute the total score.
 
+### Integration with ego-lint results
+
+After computing the taxonomy score, cross-reference with ego-lint results
+from Step 1:
+
+- Each ego-lint **FAIL** that doesn't already map to a taxonomy reason adds
+  weight 5 to the score (structural issue equivalent)
+- ego-lint **WARN** results do not add to the score but should be mentioned
+  in the Advisory Notes section of the report
+- If ego-lint reports 0 FAIL, no adjustment needed
+
+This ensures the simulation verdict reflects automated check failures that
+a real reviewer would catch immediately.
+
 Also read `references/approved-examples.md` to calibrate — note where the
 extension follows or deviates from idiomatic patterns.
 


### PR DESCRIPTION
## Summary
- Adds integration instructions to Step 3 of ego-simulate, cross-referencing ego-lint FAIL results with the taxonomy score
- Unmapped FAILs add weight 5 (structural issue equivalent); WARNs route to Advisory Notes
- Prevents silent score undercount when ego-lint catches blocking issues outside the taxonomy

Closes #3

## Test plan
- [ ] Run `ego-simulate` against an extension with ego-lint FAILs and verify the score includes unmapped failures
- [ ] Run `ego-simulate` against a clean extension and verify no score adjustment

🤖 Generated with [Claude Code](https://claude.com/claude-code)