### PR TITLE
fix(ego-lint): reduce signal-balance false positives

### DIFF
--- a/skills/ego-lint/references/rules-reference.md
+++ b/skills/ego-lint/references/rules-reference.md
@@ -1130,10 +1130,10 @@ Rules for extension lifecycle management: enable/disable hooks, signal cleanup, 
 ### R-LIFE-01: Signal Balance
 - **Severity**: advisory
 - **Checked by**: check-lifecycle.py
-- **Rule**: Detects imbalance between manual `.connect()` and `.disconnect()` calls (threshold: >2 imbalance). Recognizes `connectObject()`, `connectSmart()`, and `SignalTracker`/`SignalManager` as auto-cleanup patterns.
+- **Rule**: Detects imbalance between manual `.connect()` and `.disconnect()` calls (threshold: >2 imbalance). Recognizes `connectObject()`, `connectSmart()`, and `SignalTracker`/`SignalManager` as auto-cleanup patterns. Excludes: non-signal `.connect()` calls (no string-literal first argument), `'destroy'` signal connections (inherently self-cleaning), and signals on local/ephemeral variables (no `this` reference — garbage collected with scope).
 - **Rationale**: Unmatched signal connections are the #1 cause of extension rejections. Leaked signals cause memory leaks and crash loops.
 - **Fix**: For each `.connect()` call, ensure a matching `.disconnect()` in disable/destroy. Consider using `connectObject()` or a custom signal tracker for automatic cleanup.
-- **Tested by**: `tests/fixtures/lifecycle-basic@test/`, `tests/fixtures/signal-smart-connect@test/`
+- **Tested by**: `tests/fixtures/lifecycle-basic@test/`, `tests/fixtures/signal-smart-connect@test/`, `tests/fixtures/signal-non-gobject@test/`, `tests/fixtures/signal-destroy-connect@test/`, `tests/fixtures/signal-local-variable@test/`
 
 #### Example
 

--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -123,8 +123,13 @@ def check_signal_balance(ext_dir):
                 connect_objects += 1
             elif re.search(r'\.connectSmart\s*\(', line):
                 smart_connects += 1
-            elif re.search(r'\.connect\s*\(', line) and not re.search(r'\.disconnect', line):
-                pure_connects += 1
+            elif re.search(r"\.connect\s*\(\s*['\"]", line) and not re.search(r'\.disconnect', line):
+                if re.search(r"\.connect\s*\(\s*['\"]destroy['\"]", line):
+                    pass  # 'destroy' signal — inherently self-cleaning
+                elif not re.search(r'this[._]', line):
+                    pass  # local variable signal — inherently scoped
+                else:
+                    pure_connects += 1
             if re.search(r'\.disconnectObject\s*\(', line):
                 pass  # auto-cleanup
             elif re.search(r'\.disconnectSmart\s*\(', line):

--- a/tests/assertions/signal-balance-fp.sh
+++ b/tests/assertions/signal-balance-fp.sh
@@ -1,0 +1,23 @@
+# --- signal-non-gobject (Sub-issue A: non-signal .connect() not counted) ---
+echo "=== signal-non-gobject ==="
+run_lint "signal-non-gobject@test"
+assert_exit_code "exits with 0 (no failures)" 0
+assert_output_contains "signal balance OK" "\[PASS\].*lifecycle/signal-balance"
+assert_output_not_contains "no signal imbalance warning" "\[WARN\].*lifecycle/signal-balance"
+echo ""
+
+# --- signal-destroy-connect (Sub-issue B: destroy signal not counted) ---
+echo "=== signal-destroy-connect ==="
+run_lint "signal-destroy-connect@test"
+assert_exit_code "exits with 0 (no failures)" 0
+assert_output_contains "signal balance OK" "\[PASS\].*lifecycle/signal-balance"
+assert_output_not_contains "no signal imbalance warning" "\[WARN\].*lifecycle/signal-balance"
+echo ""
+
+# --- signal-local-variable (Sub-issue C: local-variable signal not counted) ---
+echo "=== signal-local-variable ==="
+run_lint "signal-local-variable@test"
+assert_exit_code "exits with 0 (no failures)" 0
+assert_output_contains "signal balance OK" "\[PASS\].*lifecycle/signal-balance"
+assert_output_not_contains "no signal imbalance warning" "\[WARN\].*lifecycle/signal-balance"
+echo ""

--- a/tests/fixtures/signal-destroy-connect@test/LICENSE
+++ b/tests/fixtures/signal-destroy-connect@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/signal-destroy-connect@test/extension.js
+++ b/tests/fixtures/signal-destroy-connect@test/extension.js
@@ -1,0 +1,28 @@
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class DestroySignalExtension extends Extension {
+    enable() {
+        this._settings = this.getSettings();
+        this._settingsId = this._settings.connect('changed::key', () => {});
+
+        // 'destroy' signal — self-cleaning, no disconnect needed
+        this._button = new St.Button();
+        this._button.connect('destroy', () => {
+            this._button = null;
+        });
+
+        // Another destroy signal on a different widget
+        this._icon = new St.Icon();
+        this._icon.connect('destroy', () => {
+            this._icon = null;
+        });
+    }
+
+    disable() {
+        this._settings.disconnect(this._settingsId);
+        this._settings = null;
+        this._button?.destroy();
+        this._icon?.destroy();
+    }
+}

--- a/tests/fixtures/signal-destroy-connect@test/metadata.json
+++ b/tests/fixtures/signal-destroy-connect@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "signal-destroy-connect@test",
+    "name": "Destroy Signal Connect Test",
+    "description": "Tests that destroy signal connections are not counted in signal balance",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/signal-destroy-connect"
+}

--- a/tests/fixtures/signal-local-variable@test/LICENSE
+++ b/tests/fixtures/signal-local-variable@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/signal-local-variable@test/extension.js
+++ b/tests/fixtures/signal-local-variable@test/extension.js
@@ -1,0 +1,26 @@
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class LocalVariableSignalExtension extends Extension {
+    enable() {
+        this._settings = this.getSettings();
+        this._settingsId = this._settings.connect('changed::key', () => {});
+    }
+
+    _showNotification(text) {
+        // Ephemeral local variable — signal is garbage collected with it
+        let notification = new MessageTray.Notification(this._source, text);
+        notification.connect('activated', () => {
+            Main.extensionManager.openExtensionPrefs(this.uuid);
+        });
+
+        // Another ephemeral local signal
+        let dialog = new ModalDialog.ModalDialog();
+        dialog.connect('opened', () => log('dialog opened'));
+    }
+
+    disable() {
+        this._settings.disconnect(this._settingsId);
+        this._settings = null;
+    }
+}

--- a/tests/fixtures/signal-local-variable@test/metadata.json
+++ b/tests/fixtures/signal-local-variable@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "signal-local-variable@test",
+    "name": "Local Variable Signal Test",
+    "description": "Tests that signals on local/ephemeral variables are not counted in signal balance",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/signal-local-variable"
+}

--- a/tests/fixtures/signal-non-gobject@test/LICENSE
+++ b/tests/fixtures/signal-non-gobject@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/signal-non-gobject@test/extension.js
+++ b/tests/fixtures/signal-non-gobject@test/extension.js
@@ -1,0 +1,19 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class NonGObjectConnectExtension extends Extension {
+    enable() {
+        // Non-signal .connect() — e.g., IMAP or socket connection
+        this._client = new ImapClient();
+        this._client.connect(993, 'imap.example.com');
+
+        // One real GObject signal connect + matching disconnect = balanced
+        this._settings = this.getSettings();
+        this._settingsId = this._settings.connect('changed::key', () => {});
+    }
+
+    disable() {
+        this._settings.disconnect(this._settingsId);
+        this._settings = null;
+        this._client = null;
+    }
+}

--- a/tests/fixtures/signal-non-gobject@test/metadata.json
+++ b/tests/fixtures/signal-non-gobject@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "signal-non-gobject@test",
+    "name": "Non-GObject Connect Test",
+    "description": "Tests that non-signal .connect() methods are not counted",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/signal-non-gobject"
+}


### PR DESCRIPTION
## Summary

Three independent fixes to `check_signal_balance()` in check-lifecycle.py:

- **Require string-literal first argument** for `.connect()` detection — filters out non-signal `.connect()` calls (e.g., IMAP `client.connect(port, host)`)
- **Skip 'destroy' signal connections** — inherently self-cleaning since the emitter's destruction invalidates all handlers
- **Skip signals on local/ephemeral variables** — no `this._` reference means neither receiver nor handler ID is an instance field, so the connection is garbage collected with the local scope

Closes #9, closes #10, closes #11, closes #12

## Test plan

- [x] New test fixtures: `signal-destroy-connect@test`, `signal-local-variable@test`, `signal-non-gobject@test`
- [x] New assertion file: `tests/assertions/signal-balance-fp.sh`
- [ ] `bash tests/run-tests.sh` passes all assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)