### PR TITLE
fix(ego-lint): add missing CSS shell classes to KNOWN_SHELL_CLASSES

### DIFF
--- a/tests/fixtures/css-shell-classes-extra@test/stylesheet.css
+++ b/tests/fixtures/css-shell-classes-extra@test/stylesheet.css
@@ -23,3 +23,8 @@
 .my-extension .popup-menu-arrow {
     color: red;
 }
+
+/* Compound scoped — should NOT trigger override */
+.quick-settings-grid.my-ext-grid {
+    padding: 4px;
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -600,6 +600,7 @@ assert_output_contains "detects notification-banner override" "css/shell-class-o
 assert_output_contains "detects osd-window override" "css/shell-class-override.*osd-window"
 assert_output_contains "detects slider override" "css/shell-class-override.*slider"
 assert_output_not_contains "no unscoped-class FP on new shell classes" "css/unscoped-class"
+assert_output_not_contains "compound selector not flagged" "css/shell-class-override.*quick-settings-grid"
 echo ""
 
 # --- ego-lint-ignore ---


### PR DESCRIPTION
## Summary

- Add 18 GNOME Shell theme classes to `KNOWN_SHELL_CLASSES` in `check-css.py`, confirmed against the installed `gnome-shell.css` (GNOME 47)
- Fix compound selector false positives (`.shell-class.ext-class` now correctly recognized as scoped)
- Add test fixture `css-shell-classes-extra@test` with 6 assertions

### Classes added by category

| Category | Classes |
|----------|---------|
| Popup menu (7) | `popup-menu-content`, `popup-menu-arrow`, `popup-menu-boxpointer`, `popup-menu-icon`, `popup-menu-ornament`, `popup-inactive-menu-item`, `popup-ornamented-menu-item` |
| Quick settings (4) | `quick-settings-grid`, `quick-menu-toggle`, `quick-toggle-menu`, `quick-slider` |
| Calendar/date (2) | `calendar`, `events-button` |
| Notification (1) | `notification-banner` |
| Overview/workspace (2) | `workspace-background`, `workspace-thumbnails` |
| OSD/other (2) | `osd-window`, `slider` |

### Compound selector fix

Selectors like `.quick-menu-toggle.my-ext-toggle` are now correctly skipped by `check_shell_class_override` — the non-shell class makes them specific enough to not be an unscoped override.

Closes #41

## Test plan

- [x] New fixture `css-shell-classes-extra@test` verifies override detection for new classes
- [x] No unscoped-class false positives on new shell classes
- [x] `css-dual-selector@test` still passes (compound selector fix)
- [x] Local `hara-hachi-bu` regression passes (no shell-class-override FP)
- [x] Full test suite: 565 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)