### PR TITLE
fix(ego-lint): propagate strip_comments newline preservation to all scripts

### DIFF
--- a/skills/ego-lint/scripts/build-resource-graph.py
+++ b/skills/ego-lint/scripts/build-resource-graph.py
@@ -40,9 +40,14 @@ def read_file(path):
         return f.read()
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_comments(content):
     """Remove single-line and block comments from JS content."""
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    content = re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
     return content
 

--- a/skills/ego-lint/scripts/check-accessibility.py
+++ b/skills/ego-lint/scripts/check-accessibility.py
@@ -33,9 +33,14 @@ def find_js_files(ext_dir):
     return files
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_comments(content):
     """Remove single-line and block comments."""
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    content = re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
     return content
 

--- a/skills/ego-lint/scripts/check-async.py
+++ b/skills/ego-lint/scripts/check-async.py
@@ -33,9 +33,14 @@ def find_js_files(ext_dir, exclude_prefs=True):
     return files
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_comments(content):
     """Remove single-line and block comments from JS content."""
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    content = re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
     return content
 

--- a/skills/ego-lint/scripts/check-css.py
+++ b/skills/ego-lint/scripts/check-css.py
@@ -55,9 +55,14 @@ KNOWN_SHELL_CLASSES = {
 }
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_css_comments(content):
     """Remove CSS block comments."""
-    return re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    return re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
 
 
 def find_stylesheet(ext_dir):

--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -62,10 +62,15 @@ def read_file(path):
         return f.read()
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_comments(content):
     """Remove single-line and block comments from JS content."""
     # Remove block comments
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    content = re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
     # Remove single-line comments
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
     return content

--- a/skills/ego-lint/scripts/check-prefs.py
+++ b/skills/ego-lint/scripts/check-prefs.py
@@ -22,8 +22,13 @@ def result(status, check, detail):
     print(f"{status}|{check}|{detail}")
 
 
+def _preserve_newlines(match):
+    """Replace block comment content with empty lines to preserve line numbers."""
+    return '\n' * match.group(0).count('\n')
+
+
 def strip_comments(content):
-    content = re.sub(r'/\*.*?\*/', '', content, flags=re.DOTALL)
+    content = re.sub(r'/\*.*?\*/', _preserve_newlines, content, flags=re.DOTALL)
     content = re.sub(r'//.*$', '', content, flags=re.MULTILINE)
     return content
 


### PR DESCRIPTION
## Summary

- `strip_comments()` used `re.sub(r'/\*.*?\*/', '', ...)` which collapsed multi-line block comments to empty strings, shifting all subsequent line numbers in output
- `check-init.py` already had the fix (`_preserve_newlines` helper) — propagated it to the remaining 6 scripts
- Also fixed `strip_css_comments()` in `check-css.py` which had the same bug (not listed in the original issue)

### Files modified

| Script | Function |
|--------|----------|
| `check-lifecycle.py` | `strip_comments()` |
| `check-async.py` | `strip_comments()` |
| `check-prefs.py` | `strip_comments()` |
| `check-accessibility.py` | `strip_comments()` |
| `build-resource-graph.py` | `strip_comments()` |
| `check-css.py` | `strip_css_comments()` |

## Test plan

- [x] `bash tests/run-tests.sh` — all 584 assertions pass, 0 failures
- [x] Verified all 6 files contain `_preserve_newlines` helper
- [x] No new test fixture needed — this is a line-number accuracy fix

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)