### PR TITLE
feat(ego-lint): add compat-downgrade for version-aware deprecated API gating

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -252,6 +252,28 @@ For an extension with `shell-version: ["46", "47", "48"]` (min_shell=46), the fi
 - Only use when the fix would break older versions in the extension's declared range
 - The warning message should include the compat note inline (e.g., "keep vertical for GNOME <=46 compat")
 
+### Version-Compat Downgrade (`compat-downgrade`)
+
+When a rule has `min-version` set and `compat-downgrade: true`, the severity is automatically downgraded from FAIL to WARN when the extension's minimum supported GNOME version is below the rule's `min-version`. This handles backward-compatible code: extensions targeting a wide GNOME range (e.g., 42--48) need deprecated code for older versions.
+
+```yaml
+- id: R-VER44-01
+  pattern: "\\bMeta\\.later_add\\b"
+  severity: blocking
+  message: "Meta.later_add() removed in GNOME 44"
+  min-version: 44
+  compat-downgrade: true
+```
+
+**Logic**: "This API was removed in version X (`min-version`). If the extension's minimum shell-version is < X, the deprecated code exists for backward compatibility -> WARN. If the extension only targets X or newer, there's no excuse -> FAIL."
+
+For an extension with `shell-version: ["42", "48"]` (min_shell=42), the `Meta.later_add` call is downgraded to WARN because 42 < 44 -- the code is needed for GNOME 42-43 compat. For `shell-version: ["45", "48"]` (min_shell=45), it stays FAIL because 45 >= 44 -- no reason to use the removed API.
+
+**Guidelines:**
+- Only use on rules with `min-version` -- the downgrade needs a version threshold to compare against
+- NOT appropriate for APIs removed before GNOME 40 (e.g., Tweener, Shell.KeyBindingMode) -- no reasonable backward-compat excuse
+- All R-VER44 through R-VER50 blocking rules, plus R-DEPR-04/05/10, have this field set
+
 ## Inline Suppression
 
 Add `ego-lint-ignore` comments to suppress specific findings on a per-line basis.

--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -11,6 +11,7 @@
 #     min-version: 46         # Optional: only check if extension targets this GNOME version or newer
 #     max-version: 45         # Optional: only check if extension targets this version or older
 #     guard-window: 7         # Optional: number of preceding lines to check for guard-pattern (default: 1)
+#     compat-downgrade: true  # Optional: downgrade FAIL→WARN when extension min shell-version < min-version (backward-compat code)
 #
 # Add new rules by appending to this file. See CONTRIBUTING.md for details.
 
@@ -130,6 +131,7 @@
   category: deprecated
   fix: "Replace 'const X = imports.ui.main' with 'import * as Main from \"resource:///org/gnome/shell/ui/main.js\"'."
   min-version: 45
+  compat-downgrade: true
 
 - id: R-DEPR-04-legacy
   pattern: "\\bimports\\.(ui|gi|misc)\\."
@@ -148,6 +150,8 @@
   category: deprecated
   fix: "Use this.getSettings(), this.gettext(), this.path, etc. from the Extension base class"
   skip-comments: true
+  min-version: 45
+  compat-downgrade: true
 
 - id: R-DEPR-06
   pattern: "\\bTweener\\b"
@@ -192,6 +196,8 @@
   category: deprecated
   fix: "Replace format() calls with template literals: `my ${variable} string`."
   exclude-dirs: ["service"]
+  min-version: 45
+  compat-downgrade: true
 
 - id: R-DEPR-11
   pattern: "\\bShell\\.KeyBindingMode\\b"
@@ -815,6 +821,7 @@
   fix: "Use global.compositor.get_laters().addLater(Meta.LaterType.BEFORE_REDRAW, callback)"
   min-version: 44
   replacement-pattern: "get_laters"
+  compat-downgrade: true
 
 - id: R-VER44-02
   pattern: "\\bMeta\\.later_remove\\b"
@@ -827,6 +834,7 @@
   guard-pattern: "if\\s*\\(\\s*global\\.compositor\\s*\\)"
   guard-window: 7
   replacement-pattern: "get_laters"
+  compat-downgrade: true
 
 - id: R-VER46-01
   pattern: "\\.add_actor\\s*\\("
@@ -837,6 +845,7 @@
   fix: "Replace .add_actor(child) with .add_child(child)"
   min-version: 46
   guard-pattern: "\\bif\\s*\\(.*\\.add_actor\\b"
+  compat-downgrade: true
 
 - id: R-VER46-02
   pattern: "\\.remove_actor\\s*\\("
@@ -847,6 +856,7 @@
   fix: "Replace .remove_actor(child) with .remove_child(child)"
   min-version: 46
   guard-pattern: "\\bif\\s*\\(.*\\.remove_actor\\b"
+  compat-downgrade: true
 
 - id: R-VER46-03
   pattern: "\\bClutter\\.cairo_set_source_color\\b"
@@ -856,6 +866,7 @@
   category: version-compat
   fix: "Use cr.setSourceColor(color) instead"
   min-version: 46
+  compat-downgrade: true
 
 - id: R-VER46-04
   pattern: "\\bGio\\.UnixInputStream\\b"
@@ -867,6 +878,7 @@
   min-version: 46
   guard-pattern: "\\bGioUnix\\b"
   replacement-pattern: "GioUnix"
+  compat-downgrade: true
 
 - id: R-VER46-05
   pattern: "\\bExtensionState\\.(ENABLED|DISABLED|INITIALIZED|DEACTIVATING|ACTIVATING)\\b"
@@ -877,6 +889,7 @@
   fix: "Use ACTIVE, INACTIVE, ENABLING, DISABLING instead"
   min-version: 46
   replacement-pattern: "ExtensionState.ACTIVE"
+  compat-downgrade: true
 
 - id: R-VER46-06
   pattern: "\\bBlurEffect[^;]*\\.sigma\\b|\\bBlurEffect\\s*\\(\\s*\\{[^}]*sigma"
@@ -886,6 +899,7 @@
   category: version-compat
   fix: "Use .radius instead of .sigma (radius = sigma * 2.0)"
   min-version: 46
+  compat-downgrade: true
 
 - id: R-VER46-07
   pattern: "\\bClutter\\.Container\\b"
@@ -896,6 +910,7 @@
   fix: "Use Clutter.Actor add_child/remove_child instead of Container interface methods"
   min-version: 46
   guard-pattern: "!\\s*Clutter\\.Container"
+  compat-downgrade: true
 
 # --- GNOME 47 migration (version-gated) ---
 # Clutter.Color removed in GNOME 47; use Cogl.Color.
@@ -909,6 +924,7 @@
   fix: "Import Cogl from 'gi://Cogl' and use new Cogl.Color() instead"
   min-version: 47
   guard-pattern: "Clutter\\.Color\\s*\\?"
+  compat-downgrade: true
 
 # --- GNOME 48 migration (version-gated) ---
 # Clutter.Image, Meta display functions, CSS class renames.
@@ -921,6 +937,7 @@
   category: version-compat
   fix: "Use St.ImageContent instead of Clutter.Image"
   min-version: 48
+  compat-downgrade: true
 
 - id: R-VER48-02
   pattern: "\\bMeta\\.(disable_unredirect_for_display|enable_unredirect_for_display|get_window_actors|get_window_group_for_display|get_top_window_group_for_display)\\b"
@@ -933,6 +950,7 @@
   guard-pattern: "if\\s*\\(\\s*Meta\\.disable_unredirect|PACKAGE_VERSION.*['\"]4[89]|PACKAGE_VERSION.*['\"][5-9]"
   guard-window: 10
   replacement-pattern: "global.compositor"
+  compat-downgrade: true
 
 - id: R-VER48-03
   pattern: "\\bCursorTracker\\.get_for_display\\b"
@@ -942,6 +960,7 @@
   category: version-compat
   fix: "Use global.backend.get_cursor_tracker() instead"
   min-version: 48
+  compat-downgrade: true
 
 - id: R-VER48-04
   pattern: "\\.vertical\\s*="
@@ -972,6 +991,7 @@
   category: version-compat
   fix: "Shell.SnippetHook was removed without replacement in GNOME 48"
   min-version: 48
+  compat-downgrade: true
 
 - id: R-VER48-06
   pattern: "\\.get_key_focus\\s*\\("
@@ -1003,6 +1023,7 @@
   category: version-compat
   fix: "Import Mtk from 'gi://Mtk' and use Mtk.Rectangle instead"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-02
   pattern: "\\bClutter\\.ClickAction\\b"
@@ -1014,6 +1035,7 @@
   min-version: 49
   guard-pattern: "\\|\\|\\s*Clutter\\.Click(Gesture|Action)|if\\s*\\(\\s*Clutter\\.ClickAction"
   replacement-pattern: "Clutter.ClickGesture"
+  compat-downgrade: true
 
 - id: R-VER49-03
   pattern: "\\bClutter\\.TapAction\\b"
@@ -1023,6 +1045,7 @@
   category: version-compat
   fix: "Use new Clutter.LongPressGesture() instead"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-04
   pattern: "\\bMeta\\.Window\\.get_maximized\\b"
@@ -1032,6 +1055,7 @@
   category: version-compat
   fix: "Use window.is_maximized() instead of window.get_maximized()"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-05
   pattern: "\\bCursorTracker\\.set_pointer_visible\\b"
@@ -1041,6 +1065,7 @@
   category: version-compat
   fix: "Use tracker.inhibit_cursor_visibility() / uninhibit_cursor_visibility()"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-06
   pattern: "\\bClutter\\.DragAction\\b"
@@ -1050,6 +1075,7 @@
   category: version-compat
   fix: "Use new Clutter.DragGesture() instead"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-07
   pattern: "\\bClutter\\.SwipeAction\\b"
@@ -1059,6 +1085,7 @@
   category: version-compat
   fix: "Use new Clutter.SwipeGesture() instead"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-08
   pattern: "\\bmaximize\\s*\\(\\s*(Meta\\.)?MaximizeFlags"
@@ -1071,6 +1098,7 @@
   guard-pattern: "get_maximized\\s*\\?"
   guard-window: 1
   replacement-pattern: "set_maximize_flags"
+  compat-downgrade: true
 
 - id: R-VER49-09
   pattern: "\\bAppMenuButton\\b"
@@ -1080,6 +1108,7 @@
   category: version-compat
   fix: "AppMenuButton was removed without replacement in GNOME 49"
   min-version: 49
+  compat-downgrade: true
 
 - id: R-VER49-10
   pattern: "\\bDoNotDisturbSwitch\\b"
@@ -1089,6 +1118,7 @@
   category: version-compat
   min-version: 49
   fix: "Replace DoNotDisturbSwitch with DoNotDisturbToggle"
+  compat-downgrade: true
 
 - id: R-VER49-11
   pattern: "\\bunmaximize\\s*\\([^)]*MaximizeFlags"
@@ -1101,6 +1131,7 @@
   guard-pattern: "get_maximized\\s*\\?"
   guard-window: 1
   replacement-pattern: "set_maximize_flags"
+  compat-downgrade: true
 
 # --- GNOME 50 migration (version-gated) ---
 # GNOME 50 removed X11 support and associated APIs.
@@ -1113,6 +1144,7 @@
   category: version-compat
   fix: "Remove calls to releaseKeyboard(); this function no longer exists in GNOME 50"
   min-version: 50
+  compat-downgrade: true
 
 - id: R-VER50-02
   pattern: "\\bholdKeyboard\\s*\\("
@@ -1122,6 +1154,7 @@
   category: version-compat
   fix: "Remove calls to holdKeyboard(); this function no longer exists in GNOME 50"
   min-version: 50
+  compat-downgrade: true
 
 - id: R-VER50-03
   pattern: "connect\\s*\\(\\s*['\"]show-restart-message['\"]"
@@ -1131,6 +1164,7 @@
   category: version-compat
   fix: "Remove the signal connection; restart is no longer available in GNOME 50 (Wayland only)"
   min-version: 50
+  compat-downgrade: true
 
 - id: R-VER50-04
   pattern: "connect\\s*\\(\\s*['\"]restart['\"]"
@@ -1140,6 +1174,7 @@
   category: version-compat
   fix: "Remove the signal connection; restart is no longer available in GNOME 50 (Wayland only)"
   min-version: 50
+  compat-downgrade: true
 
 - id: R-VER50-05
   pattern: "timeout_add_once|idle_add_once|timeout_add_seconds_once"

--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -295,6 +295,15 @@ def main():
             scopes = [scopes]
 
         status = 'FAIL' if severity == 'blocking' else 'WARN'
+
+        # Version-compat downgrade: if extension targets GNOME versions where
+        # this API was still valid, the deprecated code is backward-compat — WARN
+        if (status == 'FAIL' and rule.get('compat-downgrade') == 'true'
+                and min_shell is not None):
+            rule_min = rule.get('min-version')
+            if rule_min is not None and min_shell < int(rule_min):
+                status = 'WARN'
+
         found = False
         dedup_files = set()  # For deduplicate mode
         exclude_dirs = set(rule.get('exclude-dirs', []))

--- a/tests/assertions/compat-downgrade.sh
+++ b/tests/assertions/compat-downgrade.sh
@@ -1,0 +1,16 @@
+# compat-downgrade: version-aware deprecated API gating
+
+# Wide version range (42-48): R-VER44-01 should be downgraded to WARN
+echo "=== compat-downgrade-wide ==="
+run_lint "compat-downgrade-wide@test"
+assert_exit_code "exits with 0 (compat-downgrade to WARN)" 0
+assert_output_contains "R-VER44-01 downgraded to WARN" "\[WARN\].*R-VER44-01"
+assert_output_not_contains "no R-VER44-01 FAIL" "\[FAIL\].*R-VER44-01"
+echo ""
+
+# Narrow version range (45-48): R-VER44-01 should stay FAIL
+echo "=== compat-downgrade-narrow ==="
+run_lint "compat-downgrade-narrow@test"
+assert_exit_code "exits with 1 (no compat excuse)" 1
+assert_output_contains "R-VER44-01 stays FAIL" "\[FAIL\].*R-VER44-01"
+echo ""

--- a/tests/fixtures/compat-downgrade-narrow@test/LICENSE
+++ b/tests/fixtures/compat-downgrade-narrow@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/compat-downgrade-narrow@test/extension.js
+++ b/tests/fixtures/compat-downgrade-narrow@test/extension.js
@@ -1,0 +1,10 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// No backward-compat excuse: targets only GNOME 45-48
+export default class TestExtension extends Extension {
+    enable() {
+        Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {});
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/compat-downgrade-narrow@test/metadata.json
+++ b/tests/fixtures/compat-downgrade-narrow@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "compat-downgrade-narrow@test",
+    "name": "Compat Downgrade Narrow Test",
+    "description": "Extension targeting only new GNOME — deprecated APIs should FAIL",
+    "shell-version": ["45", "48"],
+    "url": "https://example.com"
+}

--- a/tests/fixtures/compat-downgrade-wide@test/LICENSE
+++ b/tests/fixtures/compat-downgrade-wide@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/compat-downgrade-wide@test/extension.js
+++ b/tests/fixtures/compat-downgrade-wide@test/extension.js
@@ -1,0 +1,9 @@
+// Backward-compat code: targets GNOME 42-48
+// Uses legacy imports (valid for GNOME 42)
+const Main = imports.ui.main;
+
+function enable() {
+    Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {});
+}
+
+function disable() {}

--- a/tests/fixtures/compat-downgrade-wide@test/metadata.json
+++ b/tests/fixtures/compat-downgrade-wide@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "compat-downgrade-wide@test",
+    "name": "Compat Downgrade Wide Test",
+    "description": "Extension targeting old+new GNOME — deprecated APIs should WARN not FAIL",
+    "shell-version": ["42", "48"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Summary
- Add `compat-downgrade` field to `patterns.yaml` that automatically downgrades FAIL to WARN when an extension's minimum `shell-version` is below the rule's `min-version`
- Applied to all R-VER44 through R-VER50 blocking rules, plus R-DEPR-04/05/10 (32 rules total)
- Skipped advisory rules (R-VER48-04b, R-VER48-06, R-VER50-05) since they're already WARN

## Motivation
Extensions targeting wide GNOME ranges (e.g., 42-48) legitimately need backward-compat code for deprecated APIs. Previously, ego-lint would FAIL these — causing false rejections. Now, if the extension's minimum shell-version is below the API removal version, the finding is downgraded to WARN (informational, no rejection).

## Changes
- `rules/patterns.yaml`: Added `compat-downgrade: true` to 26 additional blocking version-compat rules (7 were already done)
- `skills/ego-lint/scripts/apply-patterns.py`: Added compat-downgrade logic (compares `min_shell` vs rule `min-version`)
- `rules/README.md`: Added "Version-Compat Downgrade" documentation section
- `tests/fixtures/compat-downgrade-wide@test/`: Fixture with `shell-version: ["42", "48"]` — R-VER44-01 should WARN
- `tests/fixtures/compat-downgrade-narrow@test/`: Fixture with `shell-version: ["45", "48"]` — R-VER44-01 should FAIL
- `tests/assertions/compat-downgrade.sh`: Assertions for both fixtures

## Test plan
- [x] `bash tests/run-tests.sh` passes (583 passed, 0 failed)
- [x] Wide fixture (min_shell=42) exits 0, shows `[WARN] R-VER44-01`
- [x] Narrow fixture (min_shell=45) exits 1, shows `[FAIL] R-VER44-01`
- [ ] Field test runner to verify no regressions on real-world extensions

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)