### PR TITLE
fix(ego-lint): skip signal callback bodies in constructor init check

### DIFF
--- a/field-tests/annotations/tiling-shell.yaml
+++ b/field-tests/annotations/tiling-shell.yaml
@@ -23,7 +23,7 @@ findings:
     notes: "get_maximized ? .unmaximize(MaximizeFlags) : .unmaximize() — same fix as R-VER49-08."
   - id: "init/shell-modification::constructor signal callback"
     classification: fp
-    notes: "globalState.js — inside constructor signal callback, not module scope. 2 instances."
+    notes: "globalState.js — inside constructor signal callback, not module scope. 2 instances. Fixed: signal callback filter in constructor check."
   - id: "init/shell-modification::module-scope arrow fn definition"
     classification: fp
     notes: "ui.js — const fn = () => Main.layoutManager.monitors is lazy, not executed at load time. Fixed: arrow fn skip."

--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -170,6 +170,44 @@ def extract_constructor_lines(content_lines):
     return constructor_lines
 
 
+# Signal connection patterns — callbacks are deferred, not executed during
+# construction.  Shell globals inside these callbacks are not init-time
+# violations.
+SIGNAL_CONNECT = re.compile(r'\.connect(?:Object)?\s*\(')
+
+
+def filter_signal_callbacks(ctor_lines):
+    """Remove lines inside signal callback bodies from constructor lines.
+
+    Signal callbacks (.connect(), .connectObject()) are deferred — they don't
+    execute during construction, so Shell globals inside them are not init-time
+    violations.  The .connect() line itself is kept (the receiver may be a Shell
+    global that IS accessed at construction time).
+    """
+    filtered = []
+    callback_depth = 0
+
+    for lineno, line in ctor_lines:
+        if callback_depth > 0:
+            # Inside a callback body — track depth and skip
+            callback_depth += line.count('{') - line.count('}')
+            if callback_depth < 0:
+                callback_depth = 0
+            continue
+
+        # Include this line (even .connect() lines — the receiver is
+        # accessed at construction time)
+        filtered.append((lineno, line))
+
+        # If this line starts a signal callback, begin tracking its body
+        if SIGNAL_CONNECT.search(line):
+            net = line.count('{') - line.count('}')
+            if net > 0:
+                callback_depth = net
+
+    return filtered
+
+
 def check_init_modifications(ext_dir):
     """R-INIT-01: Detect Shell modifications outside enable()/disable()."""
     js_files = find_js_files(ext_dir)
@@ -215,6 +253,7 @@ def check_init_modifications(ext_dir):
         is_extension_js = os.path.basename(filepath) == 'extension.js'
         if is_extension_js:
             ctor_lines = extract_constructor_lines(lines)
+            ctor_lines = filter_signal_callbacks(ctor_lines)
             for lineno, line in ctor_lines:
                 if is_skip_line(line):
                     continue

--- a/tests/fixtures/init-constructor-signal@test/LICENSE
+++ b/tests/fixtures/init-constructor-signal@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-constructor-signal@test/extension.js
+++ b/tests/fixtures/init-constructor-signal@test/extension.js
@@ -1,0 +1,34 @@
+import GObject from 'gi://GObject';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class SignalCallbackExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
+
+        // VIOLATION: Shell global accessed directly in constructor
+        this._hasOverview = Main.sessionMode.hasOverview;
+
+        // OK: Shell global inside signal callback — deferred, not executed
+        // during construction
+        this._signalId = this.connect('notify', () => {
+            const monitors = Main.layoutManager.monitors;
+            Main.panel.addToStatusArea('test', null);
+        });
+
+        // OK: multi-line connectObject callback
+        this.connectObject('notify::visible', () => {
+            if (Main.overview.visible) {
+                Main.messageTray.close();
+            }
+        }, this);
+    }
+
+    enable() {
+        Main.panel.addToStatusArea('test', this);
+    }
+
+    disable() {
+        this.disconnect(this._signalId);
+    }
+}

--- a/tests/fixtures/init-constructor-signal@test/metadata.json
+++ b/tests/fixtures/init-constructor-signal@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-constructor-signal@test",
+    "name": "Init Constructor Signal Test",
+    "description": "Tests that signal callbacks in constructors are not flagged",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-constructor-signal"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -231,6 +231,15 @@ assert_output_not_contains "no FP on async arrow function" "init/shell-modificat
 assert_output_not_contains "no FP on arrow GObject constructor" "init/shell-modification.*extension.js:14"
 echo ""
 
+# --- init-constructor-signal ---
+echo "=== init-constructor-signal ==="
+run_lint "init-constructor-signal@test"
+assert_exit_code "exits with 1 (has constructor violation)" 1
+assert_output_contains "flags direct Shell global in constructor" "\[FAIL\].*init/shell-modification.*extension.js:10"
+assert_output_not_contains "no FP on .connect() callback body" "init/shell-modification.*extension.js:1[5-7]"
+assert_output_not_contains "no FP on .connectObject() callback body" "init/shell-modification.*extension.js:2[1-4]"
+echo ""
+
 # --- lifecycle-imbalance ---
 echo "=== lifecycle-imbalance ==="
 run_lint "lifecycle-imbalance@test"


### PR DESCRIPTION
## Summary

- Add `filter_signal_callbacks()` to `check-init.py` that excludes signal callback body lines (`.connect()`, `.connectObject()`) from the constructor init-time check, while still checking the `.connect()` line itself (the receiver may be a Shell global accessed at construction time)
- Add test fixture `init-constructor-signal@test` with both `.connect()` and `.connectObject()` callbacks containing Shell globals, plus a direct Shell global access that should still be flagged
- Mark tiling-shell annotation for constructor signal callback FP as fixed

## Context

Issue #118 identified 8 FPs for `init/shell-modification` across tiling-shell and v-shell. Research showed that 6 of 8 were already resolved by prior PRs (#21 scoped constructor checks to extension.js, #88 added arrow fn exemption). The remaining 2 (tiling-shell `globalState.js` constructor signal callbacks) are addressed by this PR.

Signal callbacks are deferred — they don't execute during construction, only when the signal fires at runtime. The `.connect()` line itself is kept because the receiver object (e.g., `Main.panel.connect(...)`) IS accessed immediately during construction.

## Test plan

- [x] New fixture `init-constructor-signal@test` verifies:
  - Direct Shell global in constructor is flagged (line 10)
  - `.connect()` callback body is NOT flagged (lines 15-17)
  - `.connectObject()` callback body is NOT flagged (lines 21-24)
- [x] All 653 existing test assertions pass (0 regressions)
- [x] Existing init fixtures unchanged: `init-time-safety`, `init-helper-constructor`, `init-modification`, `constructor-gobject`

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)