### PR TITLE
fix(ego-lint): recognize alternative cleanup methods in resource tracking

### DIFF
--- a/skills/ego-lint/references/rules-reference.md
+++ b/skills/ego-lint/references/rules-reference.md
@@ -2017,9 +2017,10 @@ Rules for APIs removed or changed in specific GNOME Shell versions. These rules 
 ### resource-tracking/no-destroy-method
 - **Severity**: advisory
 - **Checked by**: check-resources.py → build-resource-graph.py
-- **Rule**: Module creates resources but has no cleanup method (`destroy()`, `disable()`, or `onDestroy()`) for cleanup.
+- **Rule**: Module creates resources but has no recognized cleanup method.
+- **Recognized cleanup methods**: `destroy()`, `disable()`, `_destroy*()`, `onDestroy()`, `disconnect_all()`, `cleanup()`, `_cleanup*()`, `close()`, `shutdown()`, `dispose()`, `release()`.
 - **Fix**: Add a `destroy()` method that cleans up all resources, or use `onDestroy()` connected via `this.connect('destroy', this.onDestroy.bind(this))`.
-- **Note**: Suppressed when the parent calls any method on the child ref (e.g., `this._helper.disconnect_all()`) or nulls it inside a cleanup method body. This covers utility classes with custom cleanup methods managed by their parent.
+- **Note**: Also suppressed when the parent calls any method on the child ref (e.g., `this._helper.disconnect_all()`) or nulls it inside a cleanup method body, or when the parent adds the child as an actor child/effect via `add_child()` / `add_effect()` (auto-cleanup by actor lifecycle).
 
 ### resource-tracking/destroy-not-called
 - **Severity**: advisory

--- a/skills/ego-lint/scripts/build-resource-graph.py
+++ b/skills/ego-lint/scripts/build-resource-graph.py
@@ -329,7 +329,9 @@ def scan_file(file_path, ext_dir):
         any_cleanup_pat = re.compile(
             re.escape(ref) + r'(?:\??\.\w+\s*\(|\s*=\s*null\b)'
         )
-        for method_name in ('destroy', 'disable', '_destroy', 'onDestroy'):
+        for method_name in ('destroy', 'disable', '_destroy', 'onDestroy',
+                             'disconnect_all', 'cleanup', '_cleanup',
+                             'close', 'shutdown', 'dispose', 'release'):
             mb = find_method_body(content, method_name)
             if mb:
                 _, _, body = mb
@@ -342,7 +344,8 @@ def scan_file(file_path, ext_dir):
     child_refs = set()
     child_add_pat = re.compile(
         r'\.(?:add_child|insert_child_below|insert_child_above|'
-        r'insert_child_at_index|set_child|add_actor)\s*\(\s*(this[._]\w+)'
+        r'insert_child_at_index|set_child|add_actor|'
+        r'add_effect|add_effect_with_name)\s*\(\s*(this[._]\w+)'
     )
     for line in lines:
         m = child_add_pat.search(line.strip())
@@ -360,6 +363,13 @@ def scan_file(file_path, ext_dir):
     has_on_destroy = bool(re.search(
         r'(?:^|\s)onDestroy\s*\([^)]*\)\s*\{', content, re.MULTILINE
     ))
+    # Detect alternative cleanup methods: disconnect_all, cleanup, _cleanup*,
+    # close, shutdown, dispose, release
+    has_custom_cleanup = bool(re.search(
+        r'(?:^|\s)(?:disconnect_all|_?cleanup\w*|close|shutdown|dispose|release)'
+        r'\s*\([^)]*\)\s*\{',
+        content, re.MULTILINE
+    ))
 
     return {
         'rel': rel,
@@ -371,6 +381,7 @@ def scan_file(file_path, ext_dir):
         'has_disable': has_disable,
         'has_private_destroy': has_private_destroy,
         'has_on_destroy': has_on_destroy,
+        'has_custom_cleanup': has_custom_cleanup,
         'child_refs': child_refs,
         'content': content,
     }
@@ -496,7 +507,9 @@ def detect_orphans(file_scans, ownership):
         has_disable = scan['has_disable']
         has_private_destroy = scan['has_private_destroy']
         has_on_destroy = scan['has_on_destroy']
-        has_cleanup_method = has_destroy or has_disable or has_private_destroy or has_on_destroy
+        has_custom_cleanup = scan.get('has_custom_cleanup', False)
+        has_cleanup_method = (has_destroy or has_disable or has_private_destroy
+                              or has_on_destroy or has_custom_cleanup)
 
         if not creates:
             continue
@@ -519,10 +532,22 @@ def detect_orphans(file_scans, ownership):
                         parent_calls_destroy = True
                         break
 
+        # Check if parent added this child as a widget child or effect
+        # (auto-cleanup by actor lifecycle)
+        parent_manages_as_child = False
+        if parent_rel and parent_rel in file_scans:
+            parent_child_refs = file_scans[parent_rel].get('child_refs', set())
+            if parent_rel in ownership:
+                for ref, ref_info in ownership[parent_rel].items():
+                    if ref_info.get('source_file') == rel:
+                        if ref in parent_child_refs:
+                            parent_manages_as_child = True
+                            break
+
         # Case 1: Module creates resources but has no cleanup method
         if not has_cleanup_method:
-            if parent_calls_destroy:
-                continue  # Parent manages this child via custom cleanup method
+            if parent_calls_destroy or parent_manages_as_child:
+                continue  # Parent manages this child's lifecycle
             for c in creates:
                 orphans.append({
                     'file': rel,
@@ -552,7 +577,9 @@ def detect_orphans(file_scans, ownership):
         # releasing references even when the resource auto-cleans itself
         nulled_refs = set()
         content = scan['content']
-        for method_name in ('destroy', 'disable', '_destroy', 'onDestroy'):
+        for method_name in ('destroy', 'disable', '_destroy', 'onDestroy',
+                             'disconnect_all', 'cleanup', '_cleanup',
+                             'close', 'shutdown', 'dispose', 'release'):
             mb = find_method_body(content, method_name)
             if mb:
                 _, _, body = mb

--- a/tests/fixtures/custom-cleanup-method@test/LICENSE
+++ b/tests/fixtures/custom-cleanup-method@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/custom-cleanup-method@test/extension.js
+++ b/tests/fixtures/custom-cleanup-method@test/extension.js
@@ -1,0 +1,14 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import {SignalTracker} from './tracker.js';
+
+export default class TestExtension extends Extension {
+    enable() {
+        this._tracker = new SignalTracker();
+        this._tracker.track(global.display, 'window-created');
+    }
+
+    disable() {
+        this._tracker.disconnect_all();
+        this._tracker = null;
+    }
+}

--- a/tests/fixtures/custom-cleanup-method@test/metadata.json
+++ b/tests/fixtures/custom-cleanup-method@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "custom-cleanup-method@test",
+    "name": "Custom Cleanup Method Test",
+    "description": "Tests alternative cleanup method recognition",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}

--- a/tests/fixtures/custom-cleanup-method@test/tracker.js
+++ b/tests/fixtures/custom-cleanup-method@test/tracker.js
@@ -1,0 +1,17 @@
+export class SignalTracker {
+    constructor() {
+        this._handlers = [];
+    }
+
+    track(obj, signal) {
+        const id = obj.connect(signal, () => {});
+        this._handlers.push({obj, id});
+    }
+
+    disconnect_all() {
+        for (const {obj, id} of this._handlers) {
+            obj.disconnect(id);
+        }
+        this._handlers = [];
+    }
+}

--- a/tests/fixtures/effect-auto-cleanup@test/LICENSE
+++ b/tests/fixtures/effect-auto-cleanup@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/effect-auto-cleanup@test/effect.js
+++ b/tests/fixtures/effect-auto-cleanup@test/effect.js
@@ -1,0 +1,24 @@
+import GObject from 'gi://GObject';
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+
+class BlurEffect extends Clutter.Effect {
+    _init() {
+        super._init();
+        this._settings = new Gio.Settings({schema_id: 'org.test.blur'});
+        this._handlerId = this._settings.connect('changed', () => {
+            this._updateEffect();
+        });
+    }
+
+    _updateEffect() {
+        // Reconfigure effect based on settings
+    }
+}
+
+export {BlurEffect};
+
+export default GObject.registerClass(
+    {GTypeName: 'TestBlurEffect'},
+    BlurEffect,
+);

--- a/tests/fixtures/effect-auto-cleanup@test/extension.js
+++ b/tests/fixtures/effect-auto-cleanup@test/extension.js
@@ -1,0 +1,18 @@
+import GLib from 'gi://GLib';
+import St from 'gi://St';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import {BlurEffect} from './effect.js';
+
+export default class TestExtension extends Extension {
+    enable() {
+        this._overlay = new St.Widget();
+        this._effect = new BlurEffect();
+        this._overlay.add_effect(this._effect);
+    }
+
+    disable() {
+        // Destroying the overlay auto-destroys its effects
+        this._overlay.destroy();
+        this._overlay = null;
+    }
+}

--- a/tests/fixtures/effect-auto-cleanup@test/metadata.json
+++ b/tests/fixtures/effect-auto-cleanup@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "effect-auto-cleanup@test",
+    "name": "Effect Auto Cleanup Test",
+    "description": "Tests GObject effect auto-cleanup via add_effect",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -705,6 +705,30 @@ assert_output_not_contains "no no-destroy-method for widget with onDestroy" "\[W
 assert_output_contains "resource tracking ran" "(PASS|WARN|FAIL).*resource-tracking"
 echo ""
 
+# --- custom-cleanup-method (disconnect_all recognized as cleanup) ---
+echo "=== custom-cleanup-method ==="
+run_lint "custom-cleanup-method@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "no no-destroy-method for class with disconnect_all" "\[WARN\].*resource-tracking/no-destroy-method.*tracker"
+assert_output_contains "resource tracking ran" "(PASS|WARN|FAIL).*resource-tracking"
+echo ""
+
+# --- effect-auto-cleanup (add_effect auto-cleanup by parent actor) ---
+echo "=== effect-auto-cleanup ==="
+run_lint "effect-auto-cleanup@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "no no-destroy-method for effect with add_effect" "\[WARN\].*resource-tracking/no-destroy-method.*effect"
+assert_output_contains "resource tracking ran" "(PASS|WARN|FAIL).*resource-tracking"
+echo ""
+
+# --- parent-managed-cleanup (custom cleanup via disconnect_all) ---
+echo "=== parent-managed-cleanup ==="
+run_lint "parent-managed-cleanup@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "no no-destroy-method for parent-managed child" "\[WARN\].*resource-tracking/no-destroy-method"
+assert_output_contains "resource tracking ran" "(PASS|WARN|FAIL).*resource-tracking"
+echo ""
+
 # --- destroy-no-call ---
 echo "=== destroy-no-call ==="
 run_lint "destroy-no-call@test"


### PR DESCRIPTION
## Summary
- Expand `no-destroy-method` detection to recognize `disconnect_all()`, `cleanup()`, `_cleanup*()`, `close()`, `shutdown()`, `dispose()`, and `release()` as valid cleanup methods alongside the existing `destroy()`, `disable()`, `_destroy*()`, and `onDestroy()`
- Track `add_effect()` / `add_effect_with_name()` like `add_child()` — GObject effects are auto-cleaned when the parent actor is destroyed, so child files using this pattern no longer get false-positived
- Also expand the second-pass instantiation cleanup check and `nulled_refs` scan to search custom cleanup method bodies

Eliminates up to 5 field-test FPs in blur-my-shell (`paint_signals.js`, `effects_manager.js`, `upscale.js`, `downscale.js`, `gaussian_blur.js`).

Closes #119

## Test plan
- [x] New `custom-cleanup-method@test` fixture — child with `disconnect_all()`, parent calls it in `disable()`
- [x] New `effect-auto-cleanup@test` fixture — GObject effect added via `add_effect()`, no explicit cleanup on effect ref
- [x] New `parent-managed-cleanup@test` assertions (existing fixture, previously untested)
- [x] All 665 test assertions pass
- [ ] Field test: `bash scripts/field-test-runner.sh --no-fetch --extension blur-my-shell` shows reduced `no-destroy-method` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)