### PR TITLE
ci: allow main scope in PR title linter

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -36,6 +36,7 @@ jobs:
             ego-simulate
             ego-submit
             ego-field-test
+            main
           requireScope: false
           subjectPattern: ^[a-z].+$
           subjectPatternError: |


### PR DESCRIPTION
## Summary

- Adds `main` to the allowed scopes in the PR title linter
- Release-please always generates titles like `chore(main): release X.Y.Z`, which previously failed the lint check due to the unrecognised `main` scope

## Test plan

- [ ] Verify `lint-pr-title` passes on PR #14 (`chore(main): release 0.1.1`) after merge