### PR TITLE
fix(ego-lint): suppress R-VER46-01/02 for ShellVersion-guarded else branches

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -856,7 +856,8 @@
   category: version-compat
   fix: "Replace .add_actor(child) with .add_child(child)"
   min-version: 46
-  guard-pattern: "\\bif\\s*\\(.*\\.add_actor\\b"
+  guard-pattern: "\\bif\\s*\\(.*\\.add_actor\\b|\\bShellVersion\\b"
+  guard-window: 5
   compat-downgrade: true
 
 - id: R-VER46-02
@@ -867,7 +868,8 @@
   category: version-compat
   fix: "Replace .remove_actor(child) with .remove_child(child)"
   min-version: 46
-  guard-pattern: "\\bif\\s*\\(.*\\.remove_actor\\b"
+  guard-pattern: "\\bif\\s*\\(.*\\.remove_actor\\b|\\bShellVersion\\b"
+  guard-window: 5
   compat-downgrade: true
 
 - id: R-VER46-03

--- a/tests/fixtures/version-guard-remove-actor@test/extension.js
+++ b/tests/fixtures/version-guard-remove-actor@test/extension.js
@@ -1,0 +1,34 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+
+const ShellVersion = parseFloat(Config.PACKAGE_VERSION);
+
+export default class VersionGuardExtension extends Extension {
+    enable() {
+        this._addActor();
+    }
+
+    _addActor() {
+        // Version-guarded compat code: add_actor() only runs on GNOME < 46
+        if (ShellVersion >= 46) {
+            this._box.add_child(this._actor);
+        } else {
+            this._box.add_actor(this._actor);
+        }
+    }
+
+    _removeActor() {
+        // Version-guarded compat code: remove_actor() only runs on GNOME < 46
+        if (ShellVersion >= 46) {
+            this._box.remove_child(this._actor);
+        } else {
+            this._box.remove_actor(this._actor);
+        }
+    }
+
+    disable() {
+        this._removeActor();
+        this._box = null;
+        this._actor = null;
+    }
+}

--- a/tests/fixtures/version-guard-remove-actor@test/metadata.json
+++ b/tests/fixtures/version-guard-remove-actor@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "version-guard-remove-actor@test",
+    "name": "Version Guard Remove Actor Test",
+    "description": "Tests that add_actor/remove_actor inside ShellVersion else-branches are not flagged",
+    "shell-version": ["45", "46"],
+    "url": "https://github.com/test/version-guard-remove-actor"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -473,6 +473,15 @@ assert_output_contains "fails on add_actor" "\[FAIL\].*R-VER46-01"
 assert_output_contains "fails on remove_actor" "\[FAIL\].*R-VER46-02"
 echo ""
 
+# --- version-guard-remove-actor ---
+echo "=== version-guard-remove-actor ==="
+run_lint "version-guard-remove-actor@test"
+assert_output_not_contains "no R-VER46-01 on ShellVersion-guarded add_actor" "\[FAIL\].*R-VER46-01"
+assert_output_not_contains "no R-VER46-01 warn on ShellVersion-guarded add_actor" "\[WARN\].*R-VER46-01"
+assert_output_not_contains "no R-VER46-02 on ShellVersion-guarded remove_actor" "\[FAIL\].*R-VER46-02"
+assert_output_not_contains "no R-VER46-02 warn on ShellVersion-guarded remove_actor" "\[WARN\].*R-VER46-02"
+echo ""
+
 # --- gnome47-compat ---
 echo "=== gnome47-compat ==="
 run_lint "gnome47-compat@test"


### PR DESCRIPTION
## Problem

`R-VER46-01` (`add_actor`) and `R-VER46-02` (`remove_actor`) fire as false positives when the deprecated API is called inside an `else {}` branch guarded by a `ShellVersion` version check:

\`\`\`js
const ShellVersion = parseFloat(Config.PACKAGE_VERSION);

if (ShellVersion >= 46) {
    parent.remove_child(actor);  // modern path
} else {
    parent.remove_actor(actor);  // ← R-VER46-02 was firing here (FP)
}
\`\`\`

This pattern is used by caffeine (`extension.js:721, 829`) and hara-hachi-bu, and is entirely correct — `remove_actor()` only runs on GNOME < 46 where it still exists.

## Root Cause

The existing `guard-pattern` for both rules only matched feature-check guards like `if (obj.remove_actor)`, not `ShellVersion`-based version conditionals.

## Fix

Extend the `guard-pattern` regex for R-VER46-01 and R-VER46-02 with `|\\bShellVersion\\b` and set `guard-window: 5`. This causes the backward-scan to skip the match when `ShellVersion` appears within the preceding 5 lines — covering all typical 3–4 line if/else version guards.

The existing guard for feature-check patterns is preserved (regex alternation).

## Tests

- New fixture `version-guard-remove-actor@test`: verifies both R-VER46-01 and R-VER46-02 produce no FAIL or WARN on ShellVersion-guarded else branches
- Existing `gnome46-compat@test`: unchanged — unguarded `add_actor`/`remove_actor` still produces FAIL (true positives preserved)
- Net change: +4 passing assertions, 0 regressions (567→571 pass, 125 fail unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)