### PR TITLE
fix(ego-lint): auto-detect and exclude vendored files from all lint checks

### DIFF
--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -252,6 +252,56 @@ def validate_rules(rules_file):
         return 0
 
 
+# Patterns that signal a file is vendored/third-party code (checked in first 30 lines).
+# Each pattern is matched against comment lines (lines starting with // or * or /*)
+_VENDORED_SIGNALS = re.compile(
+    r'(@license\b'
+    r'|@generated\b'
+    r'|@auto-generated\b'
+    r'|Credits:\s*https?://'
+    r'|Adapted from\s+https?://'
+    r')',
+    re.IGNORECASE,
+)
+_COMMENT_LINE = re.compile(r'^\s*(//|/?\*)')
+
+
+def _is_vendored_file(filepath, scan_lines=30):
+    """Return True if the file appears to be vendored/third-party code.
+
+    Reads the first *scan_lines* lines and looks for common attribution
+    patterns that indicate the file was copied from an external source:
+    @license, @generated, Credits:, Adapted from.  Only matches inside
+    comment lines to avoid false positives in code strings.
+    """
+    try:
+        with open(filepath, encoding='utf-8', errors='replace') as f:
+            for i, line in enumerate(f):
+                if i >= scan_lines:
+                    break
+                if _COMMENT_LINE.match(line) and _VENDORED_SIGNALS.search(line):
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def _discover_vendored_files(ext_dir):
+    """Scan all JS files in ext_dir and return a set of relative paths that
+    appear to be vendored third-party code."""
+    vendored = set()
+    skip_dirs = ('node_modules', '.git', '__pycache__')
+    for filepath in glob.glob(os.path.join(ext_dir, '**', '*.js'), recursive=True):
+        if not os.path.isfile(filepath):
+            continue
+        rel = os.path.relpath(filepath, ext_dir)
+        if any(part in skip_dirs for part in rel.split(os.sep)):
+            continue
+        if _is_vendored_file(filepath):
+            vendored.add(rel.replace(os.sep, '/'))
+    return vendored
+
+
 def main():
     # Handle --validate mode
     if len(sys.argv) >= 3 and sys.argv[1] == '--validate':
@@ -272,6 +322,13 @@ def main():
     shell_versions = _get_shell_versions(ext_dir)
     min_shell = min(shell_versions) if shell_versions else None
     is_compiled_ts = os.environ.get('EGO_LINT_COMPILED_TS') == '1'
+
+    # Pre-scan: identify vendored files once and reuse across all rules
+    vendored_files = _discover_vendored_files(ext_dir)
+    if vendored_files:
+        files_list = ', '.join(sorted(vendored_files))
+        print(f"SKIP|vendored-file-exclusion|{len(vendored_files)} file(s) auto-detected as "
+              f"vendored (third-party attribution header); excluded from pattern rules: {files_list}")
 
     for rule in rules:
         rid = rule.get('id', '?')
@@ -307,6 +364,15 @@ def main():
         found = False
         dedup_files = set()  # For deduplicate mode
         exclude_dirs = set(rule.get('exclude-dirs', []))
+        # exclude-files: list of glob patterns (relative to ext_dir) for per-rule exclusions
+        exclude_files_patterns = rule.get('exclude-files', [])
+        if isinstance(exclude_files_patterns, str):
+            exclude_files_patterns = [exclude_files_patterns]
+        # Expand exclude-files globs once per rule
+        exclude_files_set = set()
+        for efpat in exclude_files_patterns:
+            for match in glob.glob(os.path.join(ext_dir, efpat), recursive=True):
+                exclude_files_set.add(os.path.realpath(match))
 
         try:
             compiled = re.compile(pattern)
@@ -345,6 +411,13 @@ def main():
                     rel_parts = rel.replace(os.sep, '/').split('/')
                     if rel_parts[0] in exclude_dirs:
                         continue
+                # Skip auto-detected vendored files
+                rel_posix = rel.replace(os.sep, '/')
+                if rel_posix in vendored_files:
+                    continue
+                # Skip per-rule excluded files
+                if exclude_files_set and os.path.realpath(filepath) in exclude_files_set:
+                    continue
                 seen.add(filepath)
                 try:
                     with open(filepath, encoding='utf-8', errors='replace') as f:

--- a/skills/ego-lint/scripts/check-quality.py
+++ b/skills/ego-lint/scripts/check-quality.py
@@ -38,15 +38,48 @@ def is_suppressed(line, check_name, prev_line=''):
     return False
 
 
+_VENDORED_SIGNALS = re.compile(
+    r'(@license\b'
+    r'|@generated\b'
+    r'|@auto-generated\b'
+    r'|Credits:\s*https?://'
+    r'|Adapted from\s+https?://'
+    r')',
+    re.IGNORECASE,
+)
+_COMMENT_LINE = re.compile(r'^\s*(//|/?\*)')
+
+
+def _is_vendored_file(filepath, scan_lines=30):
+    """Return True if the file appears to be vendored/third-party code.
+
+    Reads the first *scan_lines* lines and looks for common attribution
+    patterns: @license, @generated, Credits:, Adapted from.
+    Only matches inside comment lines to avoid false positives.
+    """
+    try:
+        with open(filepath, encoding='utf-8', errors='replace') as f:
+            for i, line in enumerate(f):
+                if i >= scan_lines:
+                    break
+                if _COMMENT_LINE.match(line) and _VENDORED_SIGNALS.search(line):
+                    return True
+    except OSError:
+        pass
+    return False
+
+
 def find_js_files(ext_dir):
-    """Find all JS files in extension directory, excluding node_modules."""
+    """Find all JS files in extension directory, excluding node_modules and vendored files."""
     skip_dirs = {'node_modules', '.git', '__pycache__'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]
         for name in filenames:
             if name.endswith('.js'):
-                files.append(os.path.join(root, name))
+                filepath = os.path.join(root, name)
+                if not _is_vendored_file(filepath):
+                    files.append(filepath)
     return files
 
 

--- a/tests/assertions/vendored-file-exclusion.sh
+++ b/tests/assertions/vendored-file-exclusion.sh
@@ -1,0 +1,16 @@
+# Vendored file exclusion tests
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_exit_code, etc.
+#
+# Verifies that files with third-party attribution headers (@license, Credits:, etc.)
+# are auto-detected as vendored and excluded from pattern rules and quality checks.
+
+echo "=== vendored-exclusion ==="
+run_lint "vendored-exclusion@test"
+assert_exit_code "exits with 0 (vendored file not flagged)" 0
+# Pattern rules must skip vendored file
+assert_output_not_contains "no R-DEPR-09 (var) from vendored file" "\[WARN\].*R-DEPR-09.*css-parser"
+# Quality module-state must skip vendored file
+assert_output_not_contains "no quality/module-state from vendored file" "\[WARN\].*quality/module-state.*css-parser"
+# SKIP notice must be emitted
+assert_output_contains "vendored-file-exclusion SKIP emitted" "\[SKIP\].*vendored-file-exclusion"
+echo ""

--- a/tests/fixtures/vendored-exclusion@test/LICENSE
+++ b/tests/fixtures/vendored-exclusion@test/LICENSE
@@ -1,0 +1,2 @@
+MIT License
+Copyright (c) 2024 Test Author

--- a/tests/fixtures/vendored-exclusion@test/extension.js
+++ b/tests/fixtures/vendored-exclusion@test/extension.js
@@ -1,0 +1,6 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class VendoredExclusionExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/vendored-exclusion@test/lib/css-parser.js
+++ b/tests/fixtures/vendored-exclusion@test/lib/css-parser.js
@@ -1,0 +1,12 @@
+// Credits: https://github.com/reworkcss/css/tree/master/lib/parse
+// Licensed under MIT
+
+// This is a vendored CSS parser. Uses ES5-style var declarations
+// that would normally trigger R-DEPR-09 warnings:
+var lineno = 1;
+var column = 1;
+
+export function parse(css) {
+    var result = {};
+    return result;
+}

--- a/tests/fixtures/vendored-exclusion@test/metadata.json
+++ b/tests/fixtures/vendored-exclusion@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "vendored-exclusion@test",
+    "name": "Vendored File Exclusion Test",
+    "description": "Tests that vendored/third-party files are excluded from pattern rules",
+    "shell-version": ["45"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

When linting an extension like [forge](https://github.com/jmmaranan/forge), vendored third-party libraries generate excessive noise. For example, forge's `lib/css/index.js` (vendored from reworkcss/css) and `lib/prefs/widgets.js` (from aylur) were producing **79 spurious warnings** — 76 from R-DEPR-09 (`var` declarations in ES5 code), plus others — drowning out the 2–3 real issues.

## Solution

Auto-detect vendored files by scanning the first 30 comment lines for third-party attribution headers:
- `@license` — minified files with license banners
- `@generated` / `@auto-generated` — codegen output
- `Credits: https://...` — inline attribution (forge's style)
- `Adapted from https://...`

Detected files are excluded from **all** lint checks:
- Tier 1 pattern rules (`apply-patterns.py`) — emits a `[SKIP] vendored-file-exclusion` notice listing excluded files
- Tier 2 quality checks (`check-quality.py`) — `find_js_files()` now filters vendored files

Additionally adds per-rule `exclude-files` glob pattern support in `apply-patterns.py` for targeted explicit exclusions.

## Results on forge

| | Before | After |
|---|---|---|
| Pattern-rule WARNs | 115 | 36 |
| Noise reduction | — | 79 warnings eliminated |

The 36 remaining WARNs are all real issues (gsettings signal leaks, gobject patterns, unmaximize API, etc.).

## Zero-config

No `.egoignore` file required. The heuristic matches on comment-line content only (avoiding false positives from string literals). 

## Test plan

- [x] New fixture `vendored-exclusion@test` with a vendored `lib/css-parser.js` (Credits: header)
- [x] New assertion `vendored-file-exclusion.sh` verifying SKIP notice and no R-DEPR-09/module-state WARNs
- [x] 580 passing / 126 failing — identical to baseline (no regressions)
- [x] Verified on forge: 115 → 36 pattern WARNs

🤖 Generated with [Claude Code](https://claude.com/claude-code)