### PR TITLE
ci: upgrade actions to Node.js 24 before 2026-06-02 deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
       - name: Run tests


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v4` → `@v6` (node20 → node24)
- Upgrades `actions/setup-python@v5` → `@v6` (node20 → node24)

GitHub Actions will force Node.js 24 as the default on 2026-06-02, at which point node20-based actions may stop working. Both v6 releases use `node24` internally (released November 2025 and September 2025 respectively).

The deprecation warning is visible in recent CI runs:
> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## Test plan

- [ ] CI passes on this PR with no Node.js deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)