### PR TITLE
fix(ego-lint): check ALL schema IDs for settings-schema match

### DIFF
--- a/skills/ego-lint/scripts/check-schema.sh
+++ b/skills/ego-lint/scripts/check-schema.sh
@@ -9,13 +9,27 @@ set -euo pipefail
 
 EXT_DIR="$(cd "${1:-.}" && pwd)"
 
-# Extract the schema id from a .gschema.xml file.
-# Uses a <schema>-specific grep to avoid picking up <enum id=> or other
-# elements that appear before <schema id=> in files with multiple top-level
-# elements (e.g. caffeine's schema has three <enum> elements first).
+# Extract ALL schema ids from a .gschema.xml file.
+# Filters to <schema\b lines to avoid matching <enum id=> or other elements.
+extract_all_schema_ids() {
+    local file="$1"
+    grep -P '<schema\b' "$file" | grep -oP 'id="[^"]*"' | sed 's/id="//;s/"//'
+}
+
+# Extract the first schema id from a .gschema.xml file.
+# For single-schema files this is the only schema. For multi-schema files
+# (e.g. a main schema + .keybindings sub-schema), prefer using
+# extract_all_schema_ids() + targeted matching instead.
 extract_schema_id() {
     local file="$1"
-    grep -P '<schema\b' "$file" | grep -oP 'id="[^"]*"' | head -1 | sed 's/id="//;s/"//'
+    extract_all_schema_ids "$file" | head -1
+}
+
+# Return true (0) if a specific schema ID exists anywhere in a .gschema.xml file.
+schema_id_in_file() {
+    local file="$1"
+    local target_id="$2"
+    extract_all_schema_ids "$file" | grep -qxF "$target_id"
 }
 
 METADATA="$EXT_DIR/metadata.json"
@@ -63,24 +77,33 @@ echo "PASS|schema/exists|Found ${#schema_files[@]} schema file(s)"
 # Validate schema IDs match metadata
 if [[ "$has_settings_schema" == true ]]; then
     for schema_file in "${schema_files[@]}"; do
-        # Extract schema id from XML (use extract_schema_id to avoid matching <enum id=> etc.)
-        schema_id="$(extract_schema_id "$schema_file")"
-        if [[ "$schema_id" == "$settings_schema" ]]; then
-            echo "PASS|schema/id-matches|Schema ID '$schema_id' matches metadata.json settings-schema"
+        # Check whether settings-schema appears as ANY <schema id=> in the file.
+        # Multi-schema XML (e.g. main schema + .keybindings sub-schema) must not
+        # fail just because a sub-schema appears first.
+        if schema_id_in_file "$schema_file" "$settings_schema"; then
+            echo "PASS|schema/id-matches|Schema ID '$settings_schema' found in $(basename "$schema_file")"
         else
-            echo "FAIL|schema/id-matches|Schema ID '$schema_id' does not match metadata.json settings-schema '$settings_schema'"
+            all_ids="$(extract_all_schema_ids "$schema_file" | paste -sd ' ')"
+            echo "FAIL|schema/id-matches|settings-schema '$settings_schema' not found in $(basename "$schema_file") (found: ${all_ids})"
         fi
     done
 fi
 
-# Validate schema filename convention: <schema-id>.gschema.xml
+# Validate schema filename convention: <settings-schema>.gschema.xml
+# When settings-schema is defined in metadata.json, the file MUST be named
+# after that ID (the primary schema). For extensions without settings-schema,
+# fall back to the first schema ID found in the file.
 for schema_file in "${schema_files[@]}"; do
-    schema_id="$(extract_schema_id "$schema_file")"
-    if [[ -n "$schema_id" ]]; then
-        expected_filename="${schema_id}.gschema.xml"
+    if [[ "$has_settings_schema" == true ]]; then
+        ref_id="$settings_schema"
+    else
+        ref_id="$(extract_schema_id "$schema_file")"
+    fi
+    if [[ -n "$ref_id" ]]; then
+        expected_filename="${ref_id}.gschema.xml"
         actual_filename="$(basename "$schema_file")"
         if [[ "$actual_filename" == "$expected_filename" ]]; then
-            echo "PASS|schema/filename-convention|Schema filename matches ID: $actual_filename"
+            echo "PASS|schema/filename-convention|Schema filename matches settings-schema: $actual_filename"
         else
             echo "FAIL|schema/filename-convention|Schema filename '$actual_filename' MUST be '$expected_filename'"
         fi

--- a/tests/fixtures/multi-schema@test/extension.js
+++ b/tests/fixtures/multi-schema@test/extension.js
@@ -1,0 +1,6 @@
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class MultiSchemaExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/multi-schema@test/metadata.json
+++ b/tests/fixtures/multi-schema@test/metadata.json
@@ -1,0 +1,8 @@
+{
+    "uuid": "multi-schema@test",
+    "name": "Multi-Schema Test",
+    "description": "Tests that schema/id-matches passes when settings-schema appears after a sub-schema (e.g. .keybindings) in gschema.xml",
+    "shell-version": ["48"],
+    "settings-schema": "org.gnome.shell.extensions.multi-schema",
+    "url": "https://github.com/test/multi-schema"
+}

--- a/tests/fixtures/multi-schema@test/schemas/org.gnome.shell.extensions.multi-schema.gschema.xml
+++ b/tests/fixtures/multi-schema@test/schemas/org.gnome.shell.extensions.multi-schema.gschema.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <!-- Sub-schema appears FIRST — this is what caused the PaperWM FP -->
+  <schema id="org.gnome.shell.extensions.multi-schema.keybindings"
+          path="/org/gnome/shell/extensions/multi-schema/keybindings/">
+    <key name="move-left" type="as">
+      <default>["&lt;Super&gt;Left"]</default>
+      <summary>Move left keybinding</summary>
+    </key>
+  </schema>
+  <!-- Main schema appears SECOND — must match settings-schema in metadata.json -->
+  <schema id="org.gnome.shell.extensions.multi-schema"
+          path="/org/gnome/shell/extensions/multi-schema/">
+    <key name="enable-feature" type="b">
+      <default>true</default>
+      <summary>Enable feature</summary>
+    </key>
+  </schema>
+</schemalist>

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -466,6 +466,15 @@ assert_exit_code "exits with 1 (has failures)" 1
 assert_output_contains "fails on schema filename" "\[FAIL\].*schema/filename-convention"
 echo ""
 
+# --- multi-schema (sub-schema appears before main schema in XML) ---
+echo "=== multi-schema ==="
+run_lint "multi-schema@test"
+assert_output_not_contains "no schema/id-matches FAIL for multi-schema XML" "\[FAIL\].*schema/id-matches"
+assert_output_not_contains "no schema/filename-convention FAIL for multi-schema XML" "\[FAIL\].*schema/filename-convention"
+assert_output_contains "id-matches passes for multi-schema XML" "\[PASS\].*schema/id-matches"
+assert_output_contains "filename-convention passes for multi-schema XML" "\[PASS\].*schema/filename-convention"
+echo ""
+
 # --- gnome46-compat ---
 echo "=== gnome46-compat ==="
 run_lint "gnome46-compat@test"


### PR DESCRIPTION
## Problem

When `gschema.xml` contains multiple `<schema>` elements (e.g. a main schema plus a `.keybindings` sub-schema), the previous code extracted only the **first** `<schema id=...>` attribute. If a sub-schema appeared first — as in **PaperWM**, where `org.gnome.shell.extensions.paperwm.keybindings` precedes the main `org.gnome.shell.extensions.paperwm` schema — `schema/id-matches` and `schema/filename-convention` both produced **false-positive FAILs** even though the correct schema was present.

## Root Cause

`extract_schema_id()` used `| head -1`, so it always returned the first `<schema id=...>` attribute regardless of order. The `schema/id-matches` check then compared that first ID against `settings-schema`, and the `schema/filename-convention` check expected the file to be named after that first ID.

## Fix

- Add `extract_all_schema_ids()` — returns all `<schema id=...>` values from a file
- Refactor `extract_schema_id()` to use it (single-schema case is unchanged)
- Add `schema_id_in_file(file, id)` — returns 0 if the target ID is in any schema element
- **`schema/id-matches`**: pass if `settings-schema` is found in **any** `<schema>` element (not just the first)
- **`schema/filename-convention`**: when `settings-schema` is defined in `metadata.json`, use it as the reference ID for the expected filename (instead of the first schema found)

## Test Coverage

- New `multi-schema@test` fixture reproduces the PaperWM layout: `.keybindings` sub-schema appears first, main schema second
- 4 new assertions: both checks produce PASS (not FAIL) on multi-schema XML

## Affected Extensions

- **PaperWM** — primary case: 2 false-positive FAILs eliminated
- Any extension using a single `gschema.xml` with sub-schemas (keybindings, overrides, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)