### PR TITLE
fix(ego-lint): remove Meta.Cursor from R-SLOP-08 hallucinated API pattern

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -644,12 +644,12 @@
 # LLMs frequently call methods that don't exist in GJS/GNOME Shell.
 
 - id: R-SLOP-08
-  pattern: "\\b(Meta\\.Screen|Meta\\.Cursor|Shell\\.WindowTracker\\.get_default\\(\\)\\.get_active_window)"
+  pattern: "\\b(Meta\\.Screen|Shell\\.WindowTracker\\.get_default\\(\\)\\.get_active_window)"
   scope: ["*.js"]
   severity: advisory
-  message: "Likely hallucinated API — Meta.Screen and Meta.Cursor do not exist"
+  message: "Likely hallucinated API — Meta.Screen does not exist; use Meta.Display or global.display"
   category: ai-slop
-  fix: "Check the GJS API docs: https://gjs-docs.gnome.org. Use Meta.Display, global.display, etc."
+  fix: "Check the GJS API docs: https://gjs-docs.gnome.org. Use Meta.Display, global.display.get_monitor_geometry() etc."
 
 - id: R-SLOP-09
   pattern: "\\bSt\\.(Button|Label|Widget)\\.(set_label|set_text|set_icon_name)\\s*\\("


### PR DESCRIPTION
## Summary

- `Meta.Cursor` is a valid GJS enum (cursor shapes for `global.display.set_cursor()`) — removes it from the "hallucinated API" pattern
- Only `Meta.Screen` is nonexistent (removed in GNOME 40)
- Updates message and fix text to only reference `Meta.Screen`

## Root Cause

PaperWM field test (`grab.js`) revealed 5 false positive WARNs:
```js
global.display.set_cursor(Meta.Cursor.GRABBING);       // legitimate
global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);  // legitimate
```

`Meta.Cursor` is defined in libmutter as an enum of cursor shapes. Verified against GJS docs.

## Test Results

583 passed, 127 failed (127 are pre-existing failures unrelated to this change). The `warns on Meta.Screen` assertion still passes — `Meta.Screen` remains in the pattern.

Closes #155