### PR TITLE
fix(R-SLOP-08): remove Meta.Cursor from hallucinated API pattern

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -644,12 +644,12 @@
 # LLMs frequently call methods that don't exist in GJS/GNOME Shell.
 
 - id: R-SLOP-08
-  pattern: "\\b(Meta\\.Screen|Meta\\.Cursor|Shell\\.WindowTracker\\.get_default\\(\\)\\.get_active_window)"
+  pattern: "\\b(Meta\\.Screen|Shell\\.WindowTracker\\.get_default\\(\\)\\.get_active_window)"
   scope: ["*.js"]
   severity: advisory
-  message: "Likely hallucinated API — Meta.Screen and Meta.Cursor do not exist"
+  message: "Likely hallucinated API — Meta.Screen does not exist in GJS"
   category: ai-slop
-  fix: "Check the GJS API docs: https://gjs-docs.gnome.org. Use Meta.Display, global.display, etc."
+  fix: "Check the GJS API docs: https://gjs-docs.gnome.org. Use Meta.Display, global.display, etc. Note: Meta.Cursor IS valid (cursor shape enum for global.display.set_cursor())."
 
 - id: R-SLOP-09
   pattern: "\\bSt\\.(Button|Label|Widget)\\.(set_label|set_text|set_icon_name)\\s*\\("


### PR DESCRIPTION
## Problem

`R-SLOP-08` incorrectly flags `Meta.Cursor` as a hallucinated API. In reality, `Meta.Cursor` is a valid GJS enum for cursor shapes used with `global.display.set_cursor()`. This caused a false positive on PaperWM (field test 2026-03-27).

Only `Meta.Screen` is nonexistent in GJS.

## Changes

- Remove `Meta.Cursor` from the `R-SLOP-08` pattern regex
- Update the message to clarify only `Meta.Screen` is invalid
- Update the fix hint to note that `Meta.Cursor` IS valid

## Tests

- All existing hallucinated-apis fixture tests pass (Meta.Screen still detected)
- 583 passed, 127 failed — identical to baseline (0 regressions)