### PR TITLE
fix: update CURRENT_STABLE to GNOME 50

### DIFF
--- a/skills/ego-lint/scripts/check-metadata.py
+++ b/skills/ego-lint/scripts/check-metadata.py
@@ -203,10 +203,10 @@ def main():
         if isinstance(sv, list):
             result("PASS", "metadata/shell-version-array", "shell-version is an array")
 
-            if "49" in sv:
-                result("PASS", "metadata/shell-version-current", "shell-version includes current GNOME 49")
+            if "50" in sv:
+                result("PASS", "metadata/shell-version-current", "shell-version includes current GNOME 50")
             else:
-                result("WARN", "metadata/shell-version-current", "shell-version does not include GNOME 49")
+                result("WARN", "metadata/shell-version-current", "shell-version does not include GNOME 50")
         else:
             result("FAIL", "metadata/shell-version-array", f"shell-version must be an array, got {type(sv).__name__}")
 
@@ -315,7 +315,7 @@ def check_gnome_trademark(meta):
                "No GNOME trademark violations in metadata")
 
 
-CURRENT_STABLE = 49
+CURRENT_STABLE = 50
 
 
 def check_url_field(meta):

--- a/tests/fixtures/multi-dev-version@test/metadata.json
+++ b/tests/fixtures/multi-dev-version@test/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "multi-dev-version@test",
     "name": "Multi Dev Version Test",
     "description": "Tests that shell-version cannot have more than one development release",
-    "shell-version": ["49", "50", "51"],
+    "shell-version": ["49", "50", "51", "52"],
     "url": "https://github.com/test/multi-dev-version"
 }


### PR DESCRIPTION
## Summary

GNOME 50 was released on 2026-03-18. This PR updates `check-metadata.py` to reflect the new stable release:

- `CURRENT_STABLE = 49` → `CURRENT_STABLE = 50` (line 318)
- `if "49" in sv:` → `if "50" in sv:` with updated PASS/WARN messages referencing GNOME 50 (lines 206–209)

Closes #175