### PR TITLE
fix: add skip-comments to R-DEPR-04, R-SEC-04, R-SEC-12

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -133,6 +133,7 @@
   fix: "Replace 'const X = imports.ui.main' with 'import * as Main from \"resource:///org/gnome/shell/ui/main.js\"'."
   min-version: 45
   compat-downgrade: true
+  skip-comments: true
 
 - id: R-DEPR-04-legacy
   pattern: "\\bimports\\.(ui|gi|misc)\\."
@@ -257,6 +258,7 @@
   category: security
   fix: "Replace sudo with pkexec and provide a polkit action file, or use a udev rule for hardware access."
   exclude-dirs: ["tests", "test"]
+  skip-comments: true
 
 - id: R-SEC-05
   pattern: "Subprocess.*'/bin/sh'.*'-c'"
@@ -384,6 +386,7 @@
   message: "Automatic system package installation is banned; extensions must not install packages without explicit user action"
   category: security
   fix: "Remove automatic package installation. Document manual installation steps for required system packages."
+  skip-comments: true
 
 # --- Prefs.js GTK3 widget detection (blocking/advisory) ---
 # GTK3 widgets with direct Adwaita replacements should use the Adw equivalent.


### PR DESCRIPTION
## Summary

Rules R-DEPR-04, R-SEC-04, and R-SEC-12 were producing false positives by matching content inside block comments — for example, commented-out legacy `imports.*` calls, a `sudo` reference in a migration note, or a package manager command in a commented example.

This PR adds `skip-comments: true` to each of these three rules, consistent with how similar rules (R-DEPR-05, R-DEPR-06, and others) already behave.

**Changed rules:**
- `R-DEPR-04` — `imports.(ui|gi|misc)` legacy syntax
- `R-SEC-04` — `sudo` usage
- `R-SEC-12` — system package manager invocations (`apt`, `dnf`, `yum`, etc.)

Closes #174