### PR TITLE
fix(ego-lint): gsettings-signal-leak FP on object-in-array cleanup pattern

### DIFF
--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -1288,6 +1288,11 @@ def check_gsettings_signal_leak(ext_dir):
             if re.search(r'\.push\s*\(\s*$', prev_stripped):
                 prev_stripped = stripped
                 continue
+            # Skip if connect() result stored as 'id' property in an object literal
+            # e.g. arr.push({ settings, id: settings.connect('changed::...', ...) })
+            if re.search(r'\bid\s*:\s*\S+\.connect\s*\(', stripped):
+                prev_stripped = stripped
+                continue
             # Skip if inside array literal (IDs collected into array)
             if in_array_literal:
                 prev_stripped = stripped


### PR DESCRIPTION
## Problem

`lifecycle/gsettings-signal-leak` fires as FAIL on extensions that store signal connections as objects in an array and clean them up by iterating that array:

```js
#connectSettings() {
    this.#settingsConnections.push({
        settings: this.#locationSettings,
        id: this.#locationSettings.connect('changed::enabled', ...),
    });
}
#disconnectSettings() {
    this.#settingsConnections.forEach(({ settings, id }) => settings.disconnect(id));
    this.#settingsConnections = [];
}
```

The rule recognizes `.push(settings.connect(...))` (plain value push) but not `.push({ ..., id: settings.connect(...) })` (object-with-id-field push).

## Fix

Added a guard in `check-lifecycle.py`: if the current line contains `id:\s*\S+\.connect(`, the signal ID is stored as an object property — skip the line.

## Evidence

Confirmed FP in Night Theme Switcher v82 — 7 false FAILs across `Timer.js` and `ColorSchemeSwitcher.js`.

Closes #179