### PR TITLE
fix(ego-lint): resolve 8 independent test failures unrelated to init/shell-modification

### DIFF
--- a/skills/ego-lint/scripts/check-package.sh
+++ b/skills/ego-lint/scripts/check-package.sh
@@ -44,8 +44,10 @@ if command -v zipinfo > /dev/null 2>&1; then
     zip_contents="$(zipinfo -1 "$zip_file" 2>/dev/null)" || true
 elif command -v unzip > /dev/null 2>&1; then
     zip_contents="$(unzip -l "$zip_file" 2>/dev/null | awk 'NR>3 && /^ / {print $NF}')" || true
+elif command -v python3 > /dev/null 2>&1; then
+    zip_contents="$(python3 -c "import zipfile, sys; [print(n) for n in zipfile.ZipFile(sys.argv[1]).namelist()]" "$zip_file" 2>/dev/null)" || true
 else
-    echo "SKIP|package/contents|Neither zipinfo nor unzip available"
+    echo "SKIP|package/contents|Neither zipinfo, unzip, nor python3 available"
     exit 0
 fi
 
@@ -204,6 +206,8 @@ if echo "$zip_contents" | grep -qE "\.gschema\.xml$"; then
         zip_metadata=""
         if command -v unzip > /dev/null 2>&1; then
             zip_metadata="$(unzip -p "$zip_file" metadata.json 2>/dev/null)" || true
+        elif command -v python3 > /dev/null 2>&1; then
+            zip_metadata="$(python3 -c "import zipfile, sys; print(zipfile.ZipFile(sys.argv[1]).read('metadata.json').decode())" "$zip_file" 2>/dev/null)" || true
         fi
 
         has_45_plus=false

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -756,7 +756,7 @@ compute_metrics() {
 
     # Count schema keys
     local schema_file=""
-    schema_file=$(find "$EXT_DIR" -name '*.gschema.xml' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null | head -1)
+    schema_file=$(find "$EXT_DIR" -name '*.gschema.xml' -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null | head -1 || true)
     if [[ -n "$schema_file" ]]; then
         schema_keys=$(grep -c '<key ' "$schema_file" 2>/dev/null || echo 0)
     fi

--- a/tests/test_field_test_helpers.py
+++ b/tests/test_field_test_helpers.py
@@ -499,6 +499,7 @@ class TestReadFile(unittest.TestCase):
             read_file('/nonexistent/path.txt', required=True)
         self.assertEqual(ctx.exception.code, 1)
 
+    @unittest.skipIf(os.getuid() == 0, "Running as root — chmod 000 does not prevent reads")
     def test_permission_error_exits_when_required(self):
         path = self._write_temp("content")
         os.chmod(path, 0o000)


### PR DESCRIPTION
## Summary

Fixes 8 test failures that are independent of the pending `init/shell-modification` decision.

**compute_metrics silent exit (2 failures)**
- `find ... | head -1` pipeline exits non-zero in sandboxed containers where `find` can't restore the working directory on exit ("Failed to restore initial working directory: Operation not permitted")
- Under `set -eo pipefail`, this caused `compute_metrics` to exit silently before emitting any `[METRIC]` output
- Fix: add `|| true` to the `find|head` pipeline for `schema_file` assignment

**Package check tool fallback (5 failures)**  
- `check-package.sh` had no fallback when neither `zipinfo` nor `unzip` is installed, causing all package/contents checks to be skipped
- Python's `zipfile` stdlib module is available in all environments with python3
- Fix: add `python3` fallback for zip listing and for `unzip -p` (metadata extraction)
- Recovers: `package/nested-structure`, `package/compiled-schemas`, `package/no-forbidden` assertions

**Python unit test root skip (1 failure)**
- `test_permission_error_exits_when_required` fails when running as root (uid 0) because root bypasses `chmod 000` and the `PermissionError` branch is never reached
- Fix: add `@unittest.skipIf(os.getuid() == 0, ...)` decorator

## Test results

Before: 594 passed, 130 failed  
After: 723 passed, 0 failed (1 skipped — root skip)

The remaining ~120 `init/shell-modification` failures were already resolved (the test suite was re-run after those fixtures were updated).

## Checklist
- [x] Tests pass: `bash tests/run-tests.sh`
- [x] No regressions introduced