### PR TITLE
fix(ego-lint): expand JS file scan to all subdirectories

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -326,21 +326,16 @@ fi
 
 console_log_hits=""
 console_log_guarded_hits=""
-if compgen -G "$EXT_DIR/*.js" > /dev/null 2>&1 || \
-   compgen -G "$EXT_DIR/lib/**/*.js" > /dev/null 2>&1; then
+# Collect all JS files under EXT_DIR, respecting standard exclusions
+_console_js_files=()
+while IFS= read -r -d '' f; do
+    _console_js_files+=("$f")
+done < <(find "$EXT_DIR" -name '*.js' \
+    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
 
-    # Build file list
-    js_files=()
-    for f in "$EXT_DIR"/*.js; do
-        [[ -f "$f" ]] && js_files+=("$f")
-    done
-    if [[ -d "$EXT_DIR/lib" ]]; then
-        while IFS= read -r -d '' f; do
-            js_files+=("$f")
-        done < <(find "$EXT_DIR/lib" -name '*.js' -print0 2>/dev/null)
-    fi
+if [[ ${#_console_js_files[@]} -gt 0 ]]; then
 
-    for f in "${js_files[@]}"; do
+    for f in "${_console_js_files[@]}"; do
         # Match console.log( but skip lines that are comments (// or *)
         while IFS= read -r match; do
             lineno="${match%%:*}"
@@ -383,25 +378,21 @@ fi
 # ---------------------------------------------------------------------------
 
 deprecated_hits=""
-if compgen -G "$EXT_DIR/*.js" > /dev/null 2>&1 || \
-   compgen -G "$EXT_DIR/lib/**/*.js" > /dev/null 2>&1; then
+# Collect all JS files under EXT_DIR, respecting standard exclusions
+_depr_js_files=()
+while IFS= read -r -d '' f; do
+    _depr_js_files+=("$f")
+done < <(find "$EXT_DIR" -name '*.js' \
+    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
 
-    js_files=()
-    for f in "$EXT_DIR"/*.js; do
-        [[ -f "$f" ]] && js_files+=("$f")
-    done
-    if [[ -d "$EXT_DIR/lib" ]]; then
-        while IFS= read -r -d '' f; do
-            js_files+=("$f")
-        done < <(find "$EXT_DIR/lib" -name '*.js' -print0 2>/dev/null)
-    fi
+if [[ ${#_depr_js_files[@]} -gt 0 ]]; then
 
     # Match both ESM and legacy import patterns for deprecated modules
     # ESM: import ... from 'mainloop' / 'bytearray' / 'lang'
     # Legacy: const X = imports.misc.mainloop / imports.lang / imports.byteArray
     deprecated_pattern="(from ['\"]mainloop['\"]|from ['\"]bytearray['\"]|from ['\"]lang['\"]|imports\.misc\.mainloop|imports\.lang|imports\.byteArray|from ['\"]ByteArray['\"]|from ['\"]Lang['\"]|from ['\"]Mainloop['\"])"
 
-    for f in "${js_files[@]}"; do
+    for f in "${_depr_js_files[@]}"; do
         while IFS= read -r match; do
             rel_path="${f#"$EXT_DIR/"}"
             deprecated_hits+="  $rel_path: $match"$'\n'


### PR DESCRIPTION
## Summary

- **Bug fixed:** `no-console-log` and `no-deprecated-modules` only scanned `$EXT_DIR/*.js` and `$EXT_DIR/lib/*.js`, silently missing files in `components/`, `src/`, `modules/`, `ui/`, and other common extension subdirectory layouts.
- **Evidence:** Field test on blur-my-shell v72 — 4 of 5 `console.log` instances (all in `components/*.js`) were not detected. The check reported "Found 1 call" when there were actually 5+.
- **Fix:** Replaced the limited file-list builder with `find(1)` over the full `EXT_DIR` tree, using the same `node_modules`/`.git` exclusions used by other checks in `ego-lint.sh`.
- **Tests:** 479 passed / 0 new failures. All `console-log` and `deprecated-modules` fixtures still pass.

## Test plan

- [ ] Verify `no-console-log` now detects calls in `components/`, `src/`, `ui/` subdirectories
- [ ] Verify `no-deprecated-modules` now detects deprecated imports outside top-level and `lib/`
- [ ] Check CI passes (tests + lint-pr-title)