### PR TITLE
fix(ego-lint): narrow resource-path-case FP on standard prefs.js ESM import

### DIFF
--- a/skills/ego-lint/scripts/check-imports.sh
+++ b/skills/ego-lint/scripts/check-imports.sh
@@ -102,15 +102,19 @@ fi
 
 # ---------------------------------------------------------------------------
 # Check resource path case: prefs uses /Shell/Extensions/, extension uses /shell/
+# Standard framework imports (resource:///org/gnome/shell/extensions/prefs.js,
+# resource:///org/gnome/shell/extensions/extension.js) are allowed everywhere.
+# Only flag the mixed-case typo: /shell/Extensions/ (lowercase s, capital E).
 # ---------------------------------------------------------------------------
 
-# prefs.js must NOT use resource:///org/gnome/shell/ (lowercase 's') — that's the extension context
+# prefs.js must NOT use resource:///org/gnome/shell/Extensions/ (mixed case) —
+# standard framework imports like resource:///org/gnome/shell/extensions/prefs.js are fine.
 if [[ -f "$EXT_DIR/prefs.js" ]]; then
     while IFS= read -r match; do
         echo "FAIL|imports/resource-path-case|prefs.js: wrong resource path case — use resource:///org/gnome/Shell/Extensions/ (capitalized Shell)"
         violations=$((violations + 1))
         break  # Report once
-    done < <(grep -nE 'resource:///org/gnome/shell/' "$EXT_DIR/prefs.js" 2>/dev/null || true)
+    done < <(grep -nE 'resource:///org/gnome/shell/Extensions/' "$EXT_DIR/prefs.js" 2>/dev/null || true)
 fi
 
 # extension.js must NOT use resource:///org/gnome/Shell/Extensions/ — that's the prefs context

--- a/tests/assertions/lifecycle-dbus-subprocess.sh
+++ b/tests/assertions/lifecycle-dbus-subprocess.sh
@@ -30,7 +30,13 @@ echo ""
 echo "=== resource-path-case ==="
 run_lint "resource-path-case@test"
 assert_exit_code "exits with 1 (has failures)" 1
-assert_output_contains "fails on wrong resource path case in prefs.js" "\[FAIL\].*imports/resource-path-case"
+assert_output_contains "fails on mixed-case resource path in prefs.js" "\[FAIL\].*imports/resource-path-case"
+echo ""
+
+# --- prefs-standard-esm-import (no FP on standard framework import) ---
+echo "=== prefs-standard-esm-import ==="
+run_lint "prefs-standard-esm-import@test"
+assert_output_not_contains "no FP on standard prefs.js ESM import" "\[FAIL\].*imports/resource-path-case"
 echo ""
 
 # --- legacy-imports-pre45 ---

--- a/tests/fixtures/prefs-standard-esm-import@test/extension.js
+++ b/tests/fixtures/prefs-standard-esm-import@test/extension.js
@@ -1,0 +1,6 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class TestExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/prefs-standard-esm-import@test/metadata.json
+++ b/tests/fixtures/prefs-standard-esm-import@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "prefs-standard-esm-import@test",
+    "name": "Prefs Standard ESM Import Test",
+    "description": "Verifies standard resource:///org/gnome/shell/extensions/prefs.js import is not flagged",
+    "version": 1,
+    "shell-version": ["45", "46", "47", "48"]
+}

--- a/tests/fixtures/prefs-standard-esm-import@test/prefs.js
+++ b/tests/fixtures/prefs-standard-esm-import@test/prefs.js
@@ -1,8 +1,6 @@
 import Adw from 'gi://Adw';
-// Standard framework import — valid, must NOT be flagged
+// Standard ESM framework import — this must NOT trigger imports/resource-path-case
 import {ExtensionPreferences} from 'resource:///org/gnome/shell/extensions/prefs.js';
-// Bug: mixed-case resource path — lowercase 's', capital 'E' is the typo being tested
-import SomeUtil from 'resource:///org/gnome/shell/Extensions/resource-path-case@test/util.js';
 
 export default class TestPrefs extends ExtensionPreferences {
     fillPreferencesWindow(window) {


### PR DESCRIPTION
## Problem

The `imports/resource-path-case` check in `check-imports.sh` was too broad. The grep pattern:

```bash
grep -nE 'resource:///org/gnome/shell/' "$EXT_DIR/prefs.js"
```

matched ANY `resource:///org/gnome/shell/` path, including the standard ESM framework import:

```js
import {ExtensionPreferences} from 'resource:///org/gnome/shell/extensions/prefs.js';
```

This is the **correct and standard** way to import `ExtensionPreferences` in prefs.js — it should never be flagged.

## Fix

Narrow the pattern to only flag the genuinely invalid mixed-case path:
`resource:///org/gnome/shell/Extensions/` (lowercase `s`, capital `E`).

All-lowercase `resource:///org/gnome/shell/extensions/<uuid>/` paths are correct for extension resource bundles and are no longer flagged.

## Changes

- `skills/ego-lint/scripts/check-imports.sh`: narrow prefs.js grep pattern from `resource:///org/gnome/shell/` → `resource:///org/gnome/shell/Extensions/`
- `tests/fixtures/resource-path-case@test/prefs.js`: update fixture to use the actually invalid mixed-case pattern (keeping the valid standard import as a non-flagged line)
- `tests/fixtures/prefs-standard-esm-import@test/`: new fixture verifying the standard ESM import produces no FP
- `tests/assertions/lifecycle-dbus-subprocess.sh`: add assertion for new fixture

## Testing

```bash
# Confirms FAIL on genuinely invalid mixed-case path
bash skills/ego-lint/scripts/check-imports.sh tests/fixtures/resource-path-case@test
# → FAIL|imports/resource-path-case|...

# Confirms NO FAIL on standard framework import
bash skills/ego-lint/scripts/check-imports.sh tests/fixtures/prefs-standard-esm-import@test
# → PASS|imports/segregation|Import contexts are properly segregated
```

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)