### PR TITLE
fix(ego-lint): downgrade Shell global reads to WARN in check-init

### DIFF
--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -219,6 +219,46 @@ def extract_constructor_lines(content_lines, class_range=None):
 # violations.
 SIGNAL_CONNECT = re.compile(r'\.connect(?:Object)?\s*\(')
 
+# Shell global READ patterns — storing a reference or connecting a signal on
+# a Shell global is NOT a mutation.  Downgrade these to WARN.
+#
+# Covers:
+#   const X = Main.panel.statusArea.quickSettings  (const/let/var binding)
+#   this._panel = Main.panel                        (instance property store)
+#   Main.panel.connect('destroy', cb)               (signal connection)
+#
+# Does NOT cover actual mutations (property assignment on the global),
+# which must remain FAIL.
+SHELL_GLOBAL_READ = re.compile(
+    r'(?:(?:const|let|var)\s+\w+)'      # variable binding
+    r'|(?:this\.\w+\s*=)'               # instance property store
+    r'|\bMain\.\w+\.connect(?:Object)?\s*\('  # signal connection on Shell global
+)
+
+# Shell global MUTATION patterns — property assignment on a Shell global
+# (or nested object) is a real init-time violation and must remain FAIL.
+SHELL_GLOBAL_MUTATION = re.compile(
+    r'\bMain\.\w+\.\w+\s*=[^=]'        # Main.panel.x = value
+    r'|\bMain\.\w+\.\w+\.\w+\s*=[^=]'  # Main.panel.a.b = value
+)
+
+
+def _classify_shell_global(line):
+    """Return 'FAIL' for Shell global mutations, 'WARN' for reads/references.
+
+    Reads (storing a reference, connecting a signal) are genuinely
+    problematic — Shell globals may not be initialized yet — but are much
+    less severe than actual mutations of Shell state.  They are common in
+    EGO-accepted extensions, so WARN is the appropriate severity.
+    """
+    stripped = line.strip()
+    if SHELL_GLOBAL_MUTATION.search(stripped):
+        return 'FAIL'
+    if SHELL_GLOBAL_READ.search(stripped):
+        return 'WARN'
+    # Default: FAIL (conservative — covers method calls like addToStatusArea)
+    return 'FAIL'
+
 
 def filter_signal_callbacks(ctor_lines):
     """Remove lines inside signal callback bodies from constructor lines.
@@ -260,6 +300,8 @@ def check_init_modifications(ext_dir):
                "No init-time Shell modifications detected")
         return
 
+    # violations: list of (severity, location) tuples
+    # severity is 'FAIL' for mutations, 'WARN' for read-only references
     violations = []
 
     for filepath in js_files:
@@ -280,7 +322,8 @@ def check_init_modifications(ext_dir):
                 # is not executed at module scope
                 if ARROW_FN_DEF.search(line):
                     continue
-                violations.append(f"{rel}:{lineno}")
+                severity = _classify_shell_global(line)
+                violations.append((severity, f"{rel}:{lineno}"))
             elif GOBJECT_CONSTRUCTORS.search(line):
                 # Arrow function definitions are lazy — not executed at
                 # module scope
@@ -289,7 +332,7 @@ def check_init_modifications(ext_dir):
                 # GObject.registerClass() returns a class, not an instance
                 if not REGISTER_CLASS.search(line) and \
                         not VALUE_TYPES.search(line):
-                    violations.append(f"{rel}:{lineno}")
+                    violations.append(('FAIL', f"{rel}:{lineno}"))
 
         # Check constructor() lines
         # Helper class constructors are runtime-only (only run when
@@ -303,14 +346,17 @@ def check_init_modifications(ext_dir):
                 if is_skip_line(line):
                     continue
                 if SHELL_GLOBALS.search(line):
-                    violations.append(f"{rel}:{lineno}")
+                    severity = _classify_shell_global(line)
+                    violations.append((severity, f"{rel}:{lineno}"))
                 elif GOBJECT_CONSTRUCTORS.search(line):
-                    violations.append(f"{rel}:{lineno}")
+                    violations.append(('FAIL', f"{rel}:{lineno}"))
 
     if violations:
-        for loc in violations:
-            result("FAIL", "init/shell-modification",
-                   f"{loc}: Shell modification outside enable()")
+        for severity, loc in violations:
+            label = ('Shell modification'
+                     if severity == 'FAIL' else 'Shell global read')
+            result(severity, "init/shell-modification",
+                   f"{loc}: {label} outside enable()")
     else:
         result("PASS", "init/shell-modification",
                "No init-time Shell modifications detected")

--- a/tests/assertions/init-helper-in-extension.sh
+++ b/tests/assertions/init-helper-in-extension.sh
@@ -1,10 +1,13 @@
 # Tests that helper class constructors in extension.js are not flagged
-# while Extension class constructors still are
+# while Extension class constructors still are.
+# Note: Extension constructor Shell global reads are downgraded to WARN
+# (Option 4) — reads are advisory, not blocking.
 # Sourced by run-tests.sh
 
 echo "=== init-helper-in-extension ==="
 run_lint "init-helper-in-extension@test"
-assert_exit_code "exits with 1 (Extension constructor violation)" 1
-assert_output_contains "flags Extension constructor Shell global" "\[FAIL\].*init/shell-modification.*extension.js:20"
+assert_exit_code "exits with 0 (WARN only, reads are advisory)" 0
+assert_output_contains "warns on Extension constructor Shell global read" "\[WARN\].*init/shell-modification.*extension.js:20"
+assert_output_not_contains "no FAIL on Shell global read" "\[FAIL\].*init/shell-modification"
 assert_output_not_contains "no FP on helper class constructor" "init/shell-modification.*extension.js:8"
 echo ""

--- a/tests/fixtures/init-constructor-signal@test/extension.js
+++ b/tests/fixtures/init-constructor-signal@test/extension.js
@@ -6,7 +6,10 @@ export default class SignalCallbackExtension extends Extension {
     constructor(metadata) {
         super(metadata);
 
-        // VIOLATION: Shell global accessed directly in constructor
+        // VIOLATION (FAIL): Shell global mutated directly in constructor
+        Main.sessionMode.currentMode = 'test';
+
+        // ADVISORY (WARN): Shell global read in constructor — reference, not mutation
         this._hasOverview = Main.sessionMode.hasOverview;
 
         // OK: Shell global inside signal callback — deferred, not executed

--- a/tests/fixtures/init-shell-connect@test/LICENSE
+++ b/tests/fixtures/init-shell-connect@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-shell-connect@test/extension.js
+++ b/tests/fixtures/init-shell-connect@test/extension.js
@@ -1,0 +1,12 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+// ADVISORY (WARN): module-scope signal connection on Shell global — connects
+// a lifecycle tracking signal, does not mutate Shell state.
+// Pattern: blur-my-shell (Main.panel.connect('destroy', ...)).
+Main.panel.connect('destroy', () => { cleanup(); });
+
+export default class InitShellConnectExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/init-shell-connect@test/metadata.json
+++ b/tests/fixtures/init-shell-connect@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-shell-connect@test",
+    "name": "Init Shell Connect Test",
+    "description": "Module-scope signal connection on Shell global — should be WARN not FAIL",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-shell-connect"
+}

--- a/tests/fixtures/init-shell-mutation@test/LICENSE
+++ b/tests/fixtures/init-shell-mutation@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-shell-mutation@test/extension.js
+++ b/tests/fixtures/init-shell-mutation@test/extension.js
@@ -1,0 +1,11 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+// TRUE VIOLATION (FAIL): module-scope property assignment on Shell global —
+// mutates Shell state outside enable().  Must remain FAIL.
+Main.panel.someProperty = true;
+
+export default class InitShellMutationExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/init-shell-mutation@test/metadata.json
+++ b/tests/fixtures/init-shell-mutation@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-shell-mutation@test",
+    "name": "Init Shell Mutation Test",
+    "description": "Module-scope Shell global mutation — must remain FAIL",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-shell-mutation"
+}

--- a/tests/fixtures/init-shell-read-const@test/LICENSE
+++ b/tests/fixtures/init-shell-read-const@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-shell-read-const@test/extension.js
+++ b/tests/fixtures/init-shell-read-const@test/extension.js
@@ -1,0 +1,16 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+// ADVISORY (WARN): module-scope const binding of Shell global — reads reference,
+// does not mutate Shell state.  Pattern: caffeine-ng, GSConnect.
+const QuickSettings = Main.panel.statusArea.quickSettings;
+
+export default class InitShellReadConstExtension extends Extension {
+    enable() {
+        this._qs = QuickSettings;
+    }
+
+    disable() {
+        this._qs = null;
+    }
+}

--- a/tests/fixtures/init-shell-read-const@test/metadata.json
+++ b/tests/fixtures/init-shell-read-const@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-shell-read-const@test",
+    "name": "Init Shell Read Const Test",
+    "description": "Module-scope const binding of Shell global — should be WARN not FAIL",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-shell-read-const"
+}

--- a/tests/fixtures/init-shell-read-this@test/LICENSE
+++ b/tests/fixtures/init-shell-read-this@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-shell-read-this@test/extension.js
+++ b/tests/fixtures/init-shell-read-this@test/extension.js
@@ -1,0 +1,21 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+export default class InitShellReadThisExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
+
+        // ADVISORY (WARN): constructor stores Shell global reference via
+        // this.x assignment — reads reference, does not mutate Shell state.
+        // Pattern: clipboard-indicator, dash-to-panel, hara-hachi-bu.
+        this._panel = Main.panel;
+    }
+
+    enable() {
+        this._panel.addToStatusArea('test', this);
+    }
+
+    disable() {
+        this._panel = null;
+    }
+}

--- a/tests/fixtures/init-shell-read-this@test/metadata.json
+++ b/tests/fixtures/init-shell-read-this@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-shell-read-this@test",
+    "name": "Init Shell Read This Test",
+    "description": "Constructor stores Shell global reference via this.x — should be WARN not FAIL",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-shell-read-this"
+}

--- a/tests/fixtures/init-time-safety@test/extension.js
+++ b/tests/fixtures/init-time-safety@test/extension.js
@@ -1,7 +1,10 @@
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-// TRUE VIOLATION: module-scope Shell global access
+// TRUE VIOLATION (FAIL): module-scope Shell global mutation
+Main.panel.someProperty = true;
+
+// ADVISORY (WARN): module-scope Shell global read — reference, not mutation
 const primaryIdx = Main.layoutManager.primaryIndex;
 
 // OK: arrow function definition is lazy (body not executed at module scope)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -245,20 +245,54 @@ echo ""
 echo "=== init-time-safety ==="
 run_lint "init-time-safety@test"
 assert_exit_code "exits with 1 (has module-scope violation)" 1
-assert_output_contains "fails on module-scope Main access" "\[FAIL\].*init/shell-modification"
+assert_output_contains "fails on module-scope Shell mutation" "\[FAIL\].*init/shell-modification.*extension.js:5"
+assert_output_contains "warns on module-scope Shell read" "\[WARN\].*init/shell-modification.*extension.js:8"
 assert_output_not_contains "no FP on helper constructor" "init/shell-modification.*helper.js"
-assert_output_not_contains "no FP on arrow function definition" "init/shell-modification.*extension.js:8"
-assert_output_not_contains "no FP on async arrow function" "init/shell-modification.*extension.js:11"
-assert_output_not_contains "no FP on arrow GObject constructor" "init/shell-modification.*extension.js:14"
+assert_output_not_contains "no FP on arrow function definition" "init/shell-modification.*extension.js:11"
+assert_output_not_contains "no FP on async arrow function" "init/shell-modification.*extension.js:14"
+assert_output_not_contains "no FP on arrow GObject constructor" "init/shell-modification.*extension.js:17"
 echo ""
 
 # --- init-constructor-signal ---
 echo "=== init-constructor-signal ==="
 run_lint "init-constructor-signal@test"
 assert_exit_code "exits with 1 (has constructor violation)" 1
-assert_output_contains "flags direct Shell global in constructor" "\[FAIL\].*init/shell-modification.*extension.js:10"
-assert_output_not_contains "no FP on .connect() callback body" "init/shell-modification.*extension.js:1[5-7]"
-assert_output_not_contains "no FP on .connectObject() callback body" "init/shell-modification.*extension.js:2[1-4]"
+assert_output_contains "fails on Shell mutation in constructor" "\[FAIL\].*init/shell-modification.*extension.js:10"
+assert_output_contains "warns on Shell read in constructor" "\[WARN\].*init/shell-modification.*extension.js:13"
+assert_output_not_contains "no FP on .connect() callback body" "init/shell-modification.*extension.js:1[7-9]"
+assert_output_not_contains "no FP on .connectObject() callback body" "init/shell-modification.*extension.js:2[3-6]"
+echo ""
+
+# --- init-shell-read-const (WARN downgrade) ---
+echo "=== init-shell-read-const ==="
+run_lint "init-shell-read-const@test"
+assert_exit_code "exits with 0 (WARN only, not FAIL)" 0
+assert_output_contains "warns on module-scope const Shell read" "\[WARN\].*init/shell-modification.*extension.js:6"
+assert_output_not_contains "no FAIL on const Shell read" "\[FAIL\].*init/shell-modification"
+echo ""
+
+# --- init-shell-read-this (WARN downgrade) ---
+echo "=== init-shell-read-this ==="
+run_lint "init-shell-read-this@test"
+assert_exit_code "exits with 0 (WARN only, not FAIL)" 0
+assert_output_contains "warns on this.x Shell read in constructor" "\[WARN\].*init/shell-modification.*extension.js:11"
+assert_output_not_contains "no FAIL on this.x Shell read" "\[FAIL\].*init/shell-modification"
+echo ""
+
+# --- init-shell-connect (WARN downgrade) ---
+echo "=== init-shell-connect ==="
+run_lint "init-shell-connect@test"
+assert_exit_code "exits with 0 (WARN only, not FAIL)" 0
+assert_output_contains "warns on module-scope Shell global signal connect" "\[WARN\].*init/shell-modification.*extension.js:7"
+assert_output_not_contains "no FAIL on Shell global signal connect" "\[FAIL\].*init/shell-modification"
+echo ""
+
+# --- init-shell-mutation (regression guard: FAIL preserved) ---
+echo "=== init-shell-mutation ==="
+run_lint "init-shell-mutation@test"
+assert_exit_code "exits with 1 (FAIL on mutation)" 1
+assert_output_contains "fails on module-scope Shell mutation" "\[FAIL\].*init/shell-modification.*extension.js:6"
+assert_output_not_contains "no false WARN on Shell mutation" "\[WARN\].*init/shell-modification"
 echo ""
 
 # --- lifecycle-imbalance ---


### PR DESCRIPTION
## Summary

Fixes 6 confirmed false positives in `check_init_modifications()` where Shell global reads (storing a reference, connecting a signal) were incorrectly flagged as FAIL — the same severity as actual Shell mutations.

**6 confirmed FP extensions (all EGO-accepted):**
- caffeine-ng: `const QuickSettingsMenu = Main.panel.statusArea.quickSettings`
- GSConnect: `const QuickSettingsMenu = Main.panel.statusArea.quickSettings`
- clipboard-indicator: `this._qs = Main.panel.statusArea.quickSettings`
- dash-to-panel: `this._panel = Main.panel`
- blur-my-shell: `Main.panel.connect('destroy', cb)`
- hara-hachi-bu: constructor Shell global reference

## Changes

- **`check-init.py`**: Adds `_classify_shell_global()` helper with two regex classifiers:
  - `SHELL_GLOBAL_READ`: `const/let/var` bindings, `this.x =` assignments, `.connect()` calls on Shell globals → **WARN**
  - `SHELL_GLOBAL_MUTATION`: `Main.panel.x = value` property assignments → **FAIL**
  - Default (method calls like `addToStatusArea`): **FAIL** (conservative)
- **4 new test fixtures**: `init-shell-read-const`, `init-shell-read-this`, `init-shell-connect`, `init-shell-mutation`
- **Updated fixtures + assertions**: `init-time-safety`, `init-constructor-signal`, `init-helper-in-extension` — updated to cover both WARN (reads) and FAIL (mutations) cases

## Test Results

740 tests pass (740 passed, 0 failed), up from 724 before the new fixtures were added.

## Closes

Resolves FPs identified in: caffeine-ng field test (2026-04-09), dash-to-panel field test (2026-04-10), blur-my-shell field test (2026-04-16), GSConnect field test (2026-04-16), Media Controls field test (2026-04-17).