### PR TITLE
docs(ego-lint): add lifecycle accuracy warning to compiled-typescript output

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -240,7 +240,7 @@ done < <(find "$EXT_DIR" -name '*.js' -not -path '*/node_modules/*' -not -path '
 
 if [[ "$COMPILED_TS" == true ]]; then
     export EGO_LINT_COMPILED_TS=1
-    print_result "WARN" "compiled-typescript" "Extension appears compiled from TypeScript — some lint checks adjusted"
+    print_result "WARN" "compiled-typescript" "Extension appears compiled from TypeScript — some lint checks adjusted; lifecycle checks have reduced accuracy for bundled output (manually verify enable()/disable() cleanup)"
 else
     print_result "PASS" "compiled-typescript" "No transpiler artifacts detected"
 fi


### PR DESCRIPTION
## Summary

Lifecycle checks (`check-lifecycle.py`) have reduced accuracy when run against esbuild-compiled TypeScript output. Short variable names from bundling evade `this.`-prefix heuristics, silently missing real signal/timeout leaks.

This PR adds a warning note to the `compiled-typescript` WARN output so reviewers know to manually verify `enable()`/`disable()` cleanup for TypeScript extensions.

**Before:** `Extension appears compiled from TypeScript — some lint checks adjusted`
**After:** `Extension appears compiled from TypeScript — some lint checks adjusted; lifecycle checks have reduced accuracy for bundled output (manually verify enable()/disable() cleanup)`

Found during Media Controls field test (2026-04-17): 30+ lifecycle issues silently missed due to compiled output patterns.

All 725 tests pass.