### PR TITLE
fix(ego-lint): add fix suggestion to no-console-log FAIL

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -364,7 +364,7 @@ fi
 if [[ -n "$console_log_hits" ]]; then
     # Count number of hits
     hit_count=$(echo -n "$console_log_hits" | grep -c '.' || true)
-    print_result "FAIL" "no-console-log" "Found $hit_count console.log() call(s)"
+    print_result "FAIL" "no-console-log" "Found $hit_count console.log() call(s)|fix: Replace with console.debug() — it is silenced by default and enabled via G_MESSAGES_DEBUG, so no custom debug toggle is needed"
 elif [[ -n "$console_log_guarded_hits" ]]; then
     # All console.log calls are inside build-type debug guards — dead code in production
     hit_count=$(echo -n "$console_log_guarded_hits" | grep -c '.' || true)


### PR DESCRIPTION
## Summary

Adds a `|fix:` hint to the `no-console-log` FAIL output pointing developers to `console.debug()` as the correct replacement.

**Before:** `[FAIL] no-console-log  Found 2 console.log() call(s)`

**After (in `--report` output):**
```
--- FIX SUGGESTIONS ---
  no-console-log: Replace with console.debug() — it is silenced by default and enabled via G_MESSAGES_DEBUG, so no custom debug toggle is needed
```

The hint doesn't change display output — `|fix:` text is stripped from inline display and only appears in the FIX SUGGESTIONS section. All console-log tests continue to pass.

## Context

Extensions sometimes use a settings-based debug guard (`if (settings.get_boolean('debug')) console.log(...)`) thinking it's the right pattern, but `console.debug()` already provides this behavior via the standard `G_MESSAGES_DEBUG` mechanism — no custom toggle needed.

🤖 Generated by [Sol/NanoClaw personal-projects initiative]