### PR TITLE
fix(ego-lint): exempt Gio.SubprocessLauncher from module-scope init check

### DIFF
--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -88,10 +88,12 @@ GOBJECT_CONSTRUCTORS = re.compile(
 # it's class registration (type definition), not resource allocation.
 REGISTER_CLASS = re.compile(r'\bGObject\.registerClass\s*\(')
 
-# Value types / data containers that don't hold system resources
+# Value types / data containers that don't hold system resources.
+# Gio.SubprocessLauncher is a configuration container (no open fds/connections)
+# created before launch(); see GLib docs — no cleanup needed.
 VALUE_TYPES = re.compile(
     r'\bnew\s+(?:GLib\.(?:Bytes|Variant|DateTime|TimeZone|Regex|Uri)'
-    r'|Cogl\.Color|Clutter\.Color)\b'
+    r'|Cogl\.Color|Clutter\.Color|Gio\.SubprocessLauncher)\b'
 )
 
 # Extension class identification for scoping constructor checks.

--- a/tests/assertions/gsconnect-fixes.sh
+++ b/tests/assertions/gsconnect-fixes.sh
@@ -21,3 +21,10 @@ run_lint "glib-bytes-init@test"
 assert_exit_code "exits with 0 (GLib.Bytes at module scope OK)" 0
 assert_output_contains "no init-time modification" "\[PASS\].*init/shell-modification"
 echo ""
+
+# --- gio-subprocesslauncher-init (Gio.SubprocessLauncher at module scope is a config container) ---
+echo "=== gio-subprocesslauncher-init ==="
+run_lint "gio-subprocesslauncher-init@test"
+assert_exit_code "exits with 0 (Gio.SubprocessLauncher at module scope OK)" 0
+assert_output_contains "no init-time modification" "\[PASS\].*init/shell-modification"
+echo ""

--- a/tests/fixtures/gio-subprocesslauncher-init@test/LICENSE
+++ b/tests/fixtures/gio-subprocesslauncher-init@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/gio-subprocesslauncher-init@test/extension.js
+++ b/tests/fixtures/gio-subprocesslauncher-init@test/extension.js
@@ -1,0 +1,18 @@
+import Gio from 'gi://Gio';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// Module-scope subprocess launcher — configuration container, no open resources
+const launcher = new Gio.SubprocessLauncher({
+    flags: Gio.SubprocessFlags.STDOUT_PIPE,
+});
+
+export default class MyExtension extends Extension {
+    enable() {
+        this._proc = launcher.spawnv(['my-helper']);
+    }
+
+    disable() {
+        this._proc?.force_exit();
+        this._proc = null;
+    }
+}

--- a/tests/fixtures/gio-subprocesslauncher-init@test/metadata.json
+++ b/tests/fixtures/gio-subprocesslauncher-init@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "gio-subprocesslauncher-init@test",
+    "name": "Gio SubprocessLauncher Init Test",
+    "description": "Tests that new Gio.SubprocessLauncher() at module scope does not trigger init/shell-modification",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/gio-subprocesslauncher-init"
+}


### PR DESCRIPTION
## Summary

`Gio.SubprocessLauncher` is a configuration container — it holds no open file descriptors or system resources until `launch()` is called. Creating one at module scope to configure subprocess flags is a valid and common pattern.

- Adds `Gio.SubprocessLauncher` to `VALUE_TYPES` in `check-init.py` (alongside `GLib.Bytes`, `GLib.Variant`, etc.)
- Adds test fixture `gio-subprocesslauncher-init@test` with a realistic extension using module-scope launcher
- Adds assertion in `gsconnect-fixes.sh` (where the FP was originally discovered via GSConnect)

## Context

GSConnect (1.5M downloads) had `new Gio.SubprocessLauncher()` at module scope (`wl_clipboard.js:11`), triggering a FAIL from `init/shell-modification`. Investigated 2026-04-18 — confirmed FP. See `findings/2026-04-18-gsconnect-investigation.md`.

## Test plan
- [ ] CI passes (lint + tests)
- [ ] New `gio-subprocesslauncher-init` fixture: exits 0, `[PASS] init/shell-modification`