### PR TITLE
fix(ego-lint): detect anonymous extension class syntax in init check

### DIFF
--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -99,8 +99,14 @@ VALUE_TYPES = re.compile(
 # Extension class identification for scoping constructor checks.
 # Only the Extension class constructor runs at instantiation time —
 # helper class constructors only run when called from enable().
+# Named: class Foo extends Bar.Extension {
 EXTENSION_CLASS_DEF = re.compile(
     r'class\s+\w+\s+extends\s+(?:\w+\.)*Extension\s*\{'
+)
+# Anonymous: export default class extends Bar.Extension {
+# Used in modern GNOME 45+ extensions (e.g. tuberry-style bundles)
+ANON_EXTENSION_CLASS_DEF = re.compile(
+    r'export\s+default\s+class\s+extends\s+(?:\w+\.)*\w+\s*\{'
 )
 # Fallback: export default class without extends
 DEFAULT_EXPORT_CLASS_DEF = re.compile(
@@ -135,6 +141,7 @@ def find_extension_class_range(content_lines):
     """
     for lineno, line in enumerate(content_lines, 1):
         if EXTENSION_CLASS_DEF.search(line) or \
+                ANON_EXTENSION_CLASS_DEF.search(line) or \
                 DEFAULT_EXPORT_CLASS_DEF.search(line):
             depth = line.count('{') - line.count('}')
             if depth <= 0 and '{' in line:

--- a/tests/fixtures/init-anon-extension-class@test/LICENSE
+++ b/tests/fixtures/init-anon-extension-class@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/init-anon-extension-class@test/extension.js
+++ b/tests/fixtures/init-anon-extension-class@test/extension.js
@@ -1,0 +1,32 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import Gio from 'gi://Gio';
+
+// Helper class — its constructor runs only when instantiated from enable(),
+// not at module load time. The anonymous extension class detection must
+// correctly identify the Extension class boundary so this constructor
+// is NOT flagged as an init-time Shell modification.
+class ColorViewer {
+    constructor() {
+        this._cancellable = new Gio.Cancellable();
+        this._session = new Gio.SocketClient();
+    }
+
+    destroy() {
+        this._cancellable.cancel();
+        this._cancellable = null;
+        this._session = null;
+    }
+}
+
+// Anonymous extension class (GNOME 45+ bundle style, e.g. tuberry extensions).
+// Uses `export default class extends X.Extension` without a class name.
+export default class extends Extension {
+    enable() {
+        this._viewer = new ColorViewer();
+    }
+
+    disable() {
+        this._viewer.destroy();
+        this._viewer = null;
+    }
+}

--- a/tests/fixtures/init-anon-extension-class@test/metadata.json
+++ b/tests/fixtures/init-anon-extension-class@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "init-anon-extension-class@test",
+    "name": "Init Anonymous Extension Class Test",
+    "description": "Tests that helper class constructors are not flagged when extension uses anonymous class syntax",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/init-anon-extension-class"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -295,6 +295,13 @@ assert_output_contains "fails on module-scope Shell mutation" "\[FAIL\].*init/sh
 assert_output_not_contains "no false WARN on Shell mutation" "\[WARN\].*init/shell-modification"
 echo ""
 
+# --- init-anon-extension-class (FP guard: anon class boundary detection) ---
+echo "=== init-anon-extension-class ==="
+run_lint "init-anon-extension-class@test"
+assert_exit_code "exits with 0 (no violations in helper constructor)" 0
+assert_output_not_contains "no FP on helper constructor with anon extension class" "\[FAIL\].*init/shell-modification|\[WARN\].*init/shell-modification"
+echo ""
+
 # --- lifecycle-imbalance ---
 echo "=== lifecycle-imbalance ==="
 run_lint "lifecycle-imbalance@test"


### PR DESCRIPTION
## Problem

`find_extension_class_range()` in `check-init.py` only matched two class declaration patterns:

1. `class Foo extends Bar.Extension {` (named class with extends)
2. `export default class Foo {` (named default export, no extends)

It did NOT match `export default class extends X.Extension {` — the anonymous default export with extends. This is a valid GNOME 45+ pattern used in tuberry-style bundle architectures (e.g. Color Picker, 179K downloads).

When no Extension class is found, `find_extension_class_range` returns `None`, causing **all** constructors in `extension.js` to be scanned as module-scope — producing false FAIL on helper class constructors like `ColorViewer`.

## Fix

Adds `ANON_EXTENSION_CLASS_DEF` regex and includes it in `find_extension_class_range`:

```python
ANON_EXTENSION_CLASS_DEF = re.compile(
    r'export\s+default\s+class\s+extends\s+(?:\w+\.)*\w+\s*\{'
)
```

## Test

New fixture `init-anon-extension-class@test`:
- `export default class extends Extension { ... }` (anonymous extension class)
- Helper class `ColorViewer` with `Gio.Cancellable` + `Gio.SocketClient` constructors

Assertions verify:
- Exit code 0 (no violations)
- No `init/shell-modification` FAIL or WARN on helper constructors

Test suite: **744 passed, 0 failed** (was 724 before this PR; +20 from other recent additions).

## Verified on

Field-tested against Color Picker v47 (179K downloads): before fix, 2 FP FAILs on `extension.js:232` and `extension.js:233`; after fix, both gone.