### PR TITLE
fix(ego-lint): skip new X() in function default parameters

### DIFF
--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -70,6 +70,13 @@ ARROW_FN_DEF = re.compile(
     r'\s*=>'                              # arrow
 )
 
+# Function default parameters: `new X()` inside a function signature's
+# parameter list is evaluated at call-time, not module-load-time.
+# Matches: function foo(a, b = new Soup.Session()) { ... }
+FUNC_PARAM_DEFAULT = re.compile(
+    r'(?:async\s+)?function\s*\w*\s*\([^{]*=\s*new\s+\w'
+)
+
 
 # Shell globals that should only be accessed inside enable()/disable()
 SHELL_GLOBALS = re.compile(
@@ -337,6 +344,9 @@ def check_init_modifications(ext_dir):
                 # Arrow function definitions are lazy — not executed at
                 # module scope
                 if ARROW_FN_DEF.search(line):
+                    continue
+                # Function default parameters are call-time, not module-load-time
+                if FUNC_PARAM_DEFAULT.search(line):
                     continue
                 # GObject.registerClass() returns a class, not an instance
                 if not REGISTER_CLASS.search(line) and \

--- a/tests/fixtures/func-default-param-init@test/extension.js
+++ b/tests/fixtures/func-default-param-init@test/extension.js
@@ -1,0 +1,24 @@
+import Soup from 'gi://Soup';
+import Gio from 'gi://Gio';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// Default param: new Soup.Session() is call-time, not module-load-time.
+// Should NOT trigger init/shell-modification.
+async function fetchData(url, session = new Soup.Session()) {
+    const msg = Soup.Message.new('GET', url);
+    const bytes = await session.send_and_read_async(msg, 0, null);
+    return new TextDecoder().decode(bytes.get_data());
+}
+
+// async function with Gio default param — also call-time.
+async function request(url, cancellable = new Gio.Cancellable()) {
+    // ...
+}
+
+export default class MyExtension extends Extension {
+    enable() {
+        fetchData('https://example.com');
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/func-default-param-init@test/metadata.json
+++ b/tests/fixtures/func-default-param-init@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "func-default-param-init@test",
+    "name": "Function Default Parameter Init Test",
+    "description": "Tests that new X() inside function default parameters does not trigger init/shell-modification",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/func-default-param-init"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -302,6 +302,14 @@ assert_exit_code "exits with 0 (no violations in helper constructor)" 0
 assert_output_not_contains "no FP on helper constructor with anon extension class" "\[FAIL\].*init/shell-modification|\[WARN\].*init/shell-modification"
 echo ""
 
+# --- func-default-param-init (FP guard: new X() in function default params) ---
+echo "=== func-default-param-init ==="
+run_lint "func-default-param-init@test"
+assert_exit_code "exits with 0 (no violations — default params are call-time)" 0
+assert_output_not_contains "no FP on Soup.Session() in function default param" "\[FAIL\].*init/shell-modification"
+assert_output_not_contains "no FP on Gio.Cancellable() in function default param" "\[FAIL\].*init/shell-modification"
+echo ""
+
 # --- lifecycle-imbalance ---
 echo "=== lifecycle-imbalance ==="
 run_lint "lifecycle-imbalance@test"


### PR DESCRIPTION
## Problem

Function signatures like `function request(url, session = new Soup.Session())` are at brace-depth 0, so `extract_module_scope_lines()` includes them. `GOBJECT_CONSTRUCTORS` then fires on the default argument — but default parameters are evaluated **at call-time**, not module-load-time. This is a false positive.

## Fix

Add `FUNC_PARAM_DEFAULT` pattern:
```python
FUNC_PARAM_DEFAULT = re.compile(
    r'(?:async\s+)?function\s*\w*\s*\([^{]*=\s*new\s+\w'
)
```

Applied as a guard alongside the existing `ARROW_FN_DEF` guard in `check_init_modifications()`. Covers both named and anonymous function declarations (`function foo(...)` and `async function foo(...)`).

## Testing

New fixture `func-default-param-init@test` with two default-param cases (`Soup.Session`, `Gio.Cancellable`). +3 assertions, 0 regressions (baseline 492/252).