### PR TITLE
fix(ego-lint): scan local parent class for enable/disable and prefs methods

### DIFF
--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -93,6 +93,31 @@ def strip_comments(content):
     return content
 
 
+def _resolve_local_parent_content(ext_dir, content):
+    """If extension.js extends a namespace from a local import, return that file's content.
+
+    Handles the pattern: import * as F from './foo.js' + export default class extends F.Bar
+    Returns stripped content of the parent file, or None if not resolved.
+    """
+    # Find 'export default class extends NAMESPACE.Something'
+    m = re.search(r'export\s+default\s+class\b[^{]*\bextends\s+(\w+)\.', content)
+    if not m:
+        return None
+    namespace = m.group(1)
+    # Find 'import * as NAMESPACE from './local.js''
+    imp = re.search(
+        rf"import\s+\*\s+as\s+{re.escape(namespace)}\s+from\s+['\"](\./[^'\"]+)['\"]",
+        content,
+    )
+    if not imp:
+        return None
+    local_path = imp.group(1).lstrip('./')
+    parent_js = os.path.join(ext_dir, local_path)
+    if not os.path.isfile(parent_js):
+        return None
+    return strip_comments(read_file(parent_js))
+
+
 def check_enable_disable(ext_dir):
     """R-LIFE-03: extension.js must define enable() and disable()."""
     ext_js = os.path.join(ext_dir, 'extension.js')
@@ -103,6 +128,15 @@ def check_enable_disable(ext_dir):
 
     has_enable = bool(re.search(r'\benable\s*\(', content))
     has_disable = bool(re.search(r'\bdisable\s*\(', content))
+
+    # If methods are missing, check whether they live in a local parent class file.
+    if not (has_enable and has_disable):
+        parent = _resolve_local_parent_content(ext_dir, content)
+        if parent:
+            if not has_enable and re.search(r'\benable\s*\(', parent):
+                has_enable = True
+            if not has_disable and re.search(r'\bdisable\s*\(', parent):
+                has_disable = True
 
     if not has_enable:
         result("FAIL", "lifecycle/enable-method", "extension.js missing enable() method")

--- a/skills/ego-lint/scripts/check-prefs.py
+++ b/skills/ego-lint/scripts/check-prefs.py
@@ -33,6 +33,30 @@ def strip_comments(content):
     return content
 
 
+def _resolve_local_parent_content(ext_dir, content):
+    """If prefs.js extends a namespace from a local import, return that file's content.
+
+    Handles: import * as UI from './ui.js' + export default class extends UI.Prefs
+    Returns stripped content of the parent file, or None if not resolved.
+    """
+    m = re.search(r'export\s+default\s+class\b[^{]*\bextends\s+(\w+)\.', content)
+    if not m:
+        return None
+    namespace = m.group(1)
+    imp = re.search(
+        rf"import\s+\*\s+as\s+{re.escape(namespace)}\s+from\s+['\"](\./[^'\"]+)['\"]",
+        content,
+    )
+    if not imp:
+        return None
+    local_path = imp.group(1).lstrip('./')
+    parent_js = os.path.join(ext_dir, local_path)
+    if not os.path.isfile(parent_js):
+        return None
+    with open(parent_js, encoding='utf-8', errors='replace') as f:
+        return strip_comments(f.read())
+
+
 def main():
     if len(sys.argv) < 2:
         result("FAIL", "prefs/args", "No extension directory provided")
@@ -55,6 +79,15 @@ def main():
     # Dual prefs pattern check
     has_widget = bool(re.search(r'\bgetPreferencesWidget\b', content))
     has_fill = bool(re.search(r'\bfillPreferencesWindow\b', content))
+
+    # If neither method found in prefs.js, check a local parent class file.
+    if not has_widget and not has_fill:
+        parent_content = _resolve_local_parent_content(ext_dir, content)
+        if parent_content:
+            if re.search(r'\bfillPreferencesWindow\b', parent_content):
+                has_fill = True
+            elif re.search(r'\bgetPreferencesWidget\b', parent_content):
+                has_widget = True
 
     if has_widget and has_fill:
         result("FAIL", "prefs/dual-prefs-pattern",

--- a/tests/assertions/parent-class-lifecycle-prefs.sh
+++ b/tests/assertions/parent-class-lifecycle-prefs.sh
@@ -1,0 +1,19 @@
+# Parent class enable/disable and prefs method inheritance assertions
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_exit_code, etc.
+
+# --- lifecycle-parent-class-enable-disable ---
+echo "=== lifecycle-parent-class-enable-disable ==="
+run_lint "lifecycle-parent-class-enable-disable@test"
+assert_exit_code "exits with 0 (no failures)" 0
+assert_output_contains "passes when enable/disable in parent class" "\[PASS\].*lifecycle/enable-disable"
+assert_output_not_contains "no enable-method FP" "\[FAIL\].*lifecycle/enable-method"
+assert_output_not_contains "no disable-method FP" "\[FAIL\].*lifecycle/disable-method"
+echo ""
+
+# --- prefs-parent-class-method ---
+echo "=== prefs-parent-class-method ==="
+run_lint "prefs-parent-class-method@test"
+assert_exit_code "exits with 0 (no failures)" 0
+assert_output_contains "passes when fillPreferencesWindow in parent class" "\[PASS\].*prefs/prefs-method"
+assert_output_not_contains "no missing-prefs-method FP" "\[FAIL\].*prefs/missing-prefs-method"
+echo ""

--- a/tests/fixtures/lifecycle-parent-class-enable-disable@test/LICENSE
+++ b/tests/fixtures/lifecycle-parent-class-enable-disable@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/lifecycle-parent-class-enable-disable@test/base.js
+++ b/tests/fixtures/lifecycle-parent-class-enable-disable@test/base.js
@@ -1,0 +1,12 @@
+// Base class providing enable/disable lifecycle for the extension.
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export class BaseExtension extends Extension {
+    enable() {
+        // base enable logic
+    }
+
+    disable() {
+        // base disable logic
+    }
+}

--- a/tests/fixtures/lifecycle-parent-class-enable-disable@test/extension.js
+++ b/tests/fixtures/lifecycle-parent-class-enable-disable@test/extension.js
@@ -1,0 +1,6 @@
+// Extension that inherits enable()/disable() from a local base class.
+import * as B from './base.js';
+
+export default class extends B.BaseExtension {
+    // enable() and disable() inherited from B.BaseExtension in base.js
+}

--- a/tests/fixtures/lifecycle-parent-class-enable-disable@test/metadata.json
+++ b/tests/fixtures/lifecycle-parent-class-enable-disable@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "lifecycle-parent-class-enable-disable@test",
+    "name": "Lifecycle Parent Class Enable Disable Test",
+    "description": "Tests that enable/disable defined in a local parent class do not produce false positive FAILs",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/lifecycle-parent-class"
+}

--- a/tests/fixtures/prefs-parent-class-method@test/LICENSE
+++ b/tests/fixtures/prefs-parent-class-method@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/prefs-parent-class-method@test/extension.js
+++ b/tests/fixtures/prefs-parent-class-method@test/extension.js
@@ -1,0 +1,6 @@
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/prefs-parent-class-method@test/metadata.json
+++ b/tests/fixtures/prefs-parent-class-method@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "prefs-parent-class-method@test",
+    "name": "Prefs Parent Class Method Test",
+    "description": "Tests that fillPreferencesWindow defined in a local parent class does not produce a false positive FAIL",
+    "shell-version": ["48"],
+    "url": "https://github.com/test/prefs-parent-class"
+}

--- a/tests/fixtures/prefs-parent-class-method@test/prefs.js
+++ b/tests/fixtures/prefs-parent-class-method@test/prefs.js
@@ -1,0 +1,6 @@
+// Preferences that inherit fillPreferencesWindow() from a local base class.
+import * as UI from './ui.js';
+
+export default class extends UI.BasePrefs {
+    // fillPreferencesWindow() inherited from UI.BasePrefs in ui.js
+}

--- a/tests/fixtures/prefs-parent-class-method@test/ui.js
+++ b/tests/fixtures/prefs-parent-class-method@test/ui.js
@@ -1,0 +1,8 @@
+// Shared UI base class providing the preferences window implementation.
+import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+export class BasePrefs extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        // base prefs implementation
+    }
+}


### PR DESCRIPTION
## Summary

- `check-lifecycle.py`: when `extension.js` has no `enable()`/`disable()` but extends a local module (via `import * as X from './foo.js'`), scan that module for the missing methods before emitting a FAIL
- `check-prefs.py`: same pattern for `fillPreferencesWindow()`/`getPreferencesWidget()` when `prefs.js` extends a local bundle module
- Test fixtures added for both cases; 751/0 CI

**Root cause:** Color Picker v47 (tuberry-style bundle architecture) inherits `enable()`/`disable()` from `fubar.js` and `fillPreferencesWindow()` from `ui.js`. The checks only scanned the primary file, producing 3 false-positive FAILs.

## Test plan

- [x] `lifecycle-parent-class-enable-disable@test` — `[PASS] lifecycle/enable-disable` (no enable-method/disable-method FAILs)
- [x] `prefs-parent-class-method@test` — `[PASS] prefs/prefs-method` (no missing-prefs-method FAIL)
- [x] Full suite: 751/0 (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)