### PR TITLE
fix(ego-lint): narrow schema-usage accessor regex to GSettings methods only

### DIFF
--- a/skills/ego-lint/scripts/check-schema-usage.py
+++ b/skills/ego-lint/scripts/check-schema-usage.py
@@ -58,6 +58,15 @@ def parse_schema_keys(schema_files):
     return keys
 
 
+_GSETTINGS_GETTERS = (
+    r'get_(?:boolean|default_value|double|enum|flags|int64|int|mapped'
+    r'|string|strv|uint64|uint|user_value|value)'
+)
+_GSETTINGS_SETTERS = (
+    r'set_(?:boolean|double|enum|flags|int64|int|string|strv|uint64|uint|value)'
+)
+
+
 def find_key_references(js_files):
     """Scan JS files for GSettings key name references.
 
@@ -78,21 +87,27 @@ def find_key_references(js_files):
         set_uint('key-name', ...)
         bind('key-name', ...)
         connect('changed::key-name', ...)
+
+    Note: only GSettings methods are matched — GTK Builder get_object() and
+    GObject set_property() are intentionally excluded.
     """
     keys = set()
     has_dynamic = False
 
-    # Match get_*/set_*/bind with string literal key
+    # Match known GSettings get_*/set_*/bind with string literal key.
+    # Deliberately excludes non-GSettings methods like get_object() and
+    # set_property() to avoid false positives on GTK Builder widget IDs.
     accessor_re = re.compile(
-        r'\.(get_\w+|set_\w+|bind)\s*\(\s*["\']([a-z][a-z0-9-]*)["\']'
+        rf'\.({_GSETTINGS_GETTERS}|{_GSETTINGS_SETTERS}|bind)'
+        r'\s*\(\s*["\']([a-z][a-z0-9-]*)["\']'
     )
     # Match connect('changed::key-name', ...)
     changed_re = re.compile(
         r"\.connect\s*\(\s*['\"]changed::([a-z][a-z0-9-]*)['\"]"
     )
-    # Detect dynamic key access (variable or template literal)
+    # Detect dynamic GSettings key access (variable or template literal)
     dynamic_re = re.compile(
-        r'\.(get_\w+|set_\w+|bind)\s*\(\s*(`[^`]*`|\w+\s*[+,)])'
+        rf'\.({_GSETTINGS_GETTERS}|{_GSETTINGS_SETTERS}|bind)\s*\(\s*(`[^`]*`|\w+\s*[+,)])'
     )
 
     for path in js_files:


### PR DESCRIPTION
## Problem

\`schema-usage/undefined-key\` produced false-positive FAILs when extensions used:
- **\`Gtk.Builder.get_object('widget-id')\`** — GTK Builder widget IDs treated as GSettings key references
- **\`GObject.set_property('prop-name', value)\`** — GObject property names treated as GSettings key references

Root cause: \`accessor_re\` used \`get_\w+|set_\w+\` which matches any method starting with \`get_\` or \`set_\`, not just GSettings accessors.

## Fix

Replace the broad \`get_\w+|set_\w+\` pattern with explicit lists of known GSettings getter/setter methods in both \`accessor_re\` and \`dynamic_re\`.

## Evidence

Field test of **RunCat v32** (\`win0err/gnome-runcat\`, 100K+ downloads) produced 9 false-positive undefined keys: \`about-dialog\`, \`box\`, \`icon\`, \`label\`, \`logo\`, \`menu-button\`, \`preferences-general\`, \`reset\`, \`version\`.

All are GTK Builder widget IDs (from \`builder.get_object()\`) or GObject property names (from \`object.set_property()\`).

After fix: \`schema-usage/undefined-key\` no longer fires. RunCat correctly shows 2 real FAILs (\`no-console-log\`, \`imports/no-gtk-in-extension\`).

## Test

All 754 existing tests pass.

Closes #203