### PR TITLE
fix(ego-lint): exclude dev directories from non-gjs-scripts and script-permissions

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -452,9 +452,9 @@ while IFS= read -r -d '' f; do
     non_gjs_scripts+="  $rel_path"$'\n'
 done < <(find "$EXT_DIR" -type f \( -name '*.py' -o -name '*.sh' -o -name '*.rb' -o -name '*.pl' \) \
     -not -path '*/node_modules/*' -not -path '*/.git/*' \
-    -not -path '*/scripts/*' -not -path '*/tests/*' -not -path '*/test/*' \
-    -not -path '*/kwin/*' -not -path '*/docs/*' -not -path '*/.github/*' \
-    -not -path '*/ci/*' -not -path '*/build/*' \
+    -not -path "$EXT_DIR/scripts/*" -not -path "$EXT_DIR/tests/*" -not -path "$EXT_DIR/test/*" \
+    -not -path "$EXT_DIR/kwin/*" -not -path "$EXT_DIR/docs/*" -not -path "$EXT_DIR/.github/*" \
+    -not -path "$EXT_DIR/ci/*" -not -path "$EXT_DIR/build/*" \
     -print0 2>/dev/null)
 
 if [[ -n "$non_gjs_scripts" ]]; then
@@ -488,9 +488,9 @@ while IFS= read -r -d '' f; do
     fi
 done < <(find "$EXT_DIR" -type f -name '*.sh' \
     -not -path '*/node_modules/*' -not -path '*/.git/*' \
-    -not -path '*/scripts/*' -not -path '*/tests/*' -not -path '*/test/*' \
-    -not -path '*/kwin/*' -not -path '*/docs/*' -not -path '*/.github/*' \
-    -not -path '*/ci/*' -not -path '*/build/*' \
+    -not -path "$EXT_DIR/scripts/*" -not -path "$EXT_DIR/tests/*" -not -path "$EXT_DIR/test/*" \
+    -not -path "$EXT_DIR/kwin/*" -not -path "$EXT_DIR/docs/*" -not -path "$EXT_DIR/.github/*" \
+    -not -path "$EXT_DIR/ci/*" -not -path "$EXT_DIR/build/*" \
     -print0 2>/dev/null)
 
 if [[ -n "$non_exec_scripts" ]]; then

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -451,7 +451,11 @@ while IFS= read -r -d '' f; do
     rel_path="${f#"$EXT_DIR/"}"
     non_gjs_scripts+="  $rel_path"$'\n'
 done < <(find "$EXT_DIR" -type f \( -name '*.py' -o -name '*.sh' -o -name '*.rb' -o -name '*.pl' \) \
-    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
+    -not -path '*/node_modules/*' -not -path '*/.git/*' \
+    -not -path '*/scripts/*' -not -path '*/tests/*' -not -path '*/test/*' \
+    -not -path '*/kwin/*' -not -path '*/docs/*' -not -path '*/.github/*' \
+    -not -path '*/ci/*' -not -path '*/build/*' \
+    -print0 2>/dev/null)
 
 if [[ -n "$non_gjs_scripts" ]]; then
     hit_count=$(echo -n "$non_gjs_scripts" | grep -c '.' || true)
@@ -483,7 +487,11 @@ while IFS= read -r -d '' f; do
         non_exec_scripts+="  $rel_path"$'\n'
     fi
 done < <(find "$EXT_DIR" -type f -name '*.sh' \
-    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
+    -not -path '*/node_modules/*' -not -path '*/.git/*' \
+    -not -path '*/scripts/*' -not -path '*/tests/*' -not -path '*/test/*' \
+    -not -path '*/kwin/*' -not -path '*/docs/*' -not -path '*/.github/*' \
+    -not -path '*/ci/*' -not -path '*/build/*' \
+    -print0 2>/dev/null)
 
 if [[ -n "$non_exec_scripts" ]]; then
     hit_count=$(echo -n "$non_exec_scripts" | grep -c '.' || true)
@@ -839,3 +847,4 @@ if [[ $FAIL_COUNT -gt 0 ]]; then
 else
     exit 0
 fi
+


### PR DESCRIPTION
## Summary

Adds common development directory exclusions to the `non-gjs-scripts` and `script-permissions` checks in `ego-lint.sh`.

**Problem:** When ego-lint is run on a full repo checkout (the normal developer workflow), it flags development scripts in directories like `scripts/`, `tests/`, `kwin/` etc. as false positive WARNs. These dev scripts are never included in the EGO submission ZIP, so the warnings are noise.

**Evidence:** Field test of Burn My Windows against v0.1.14 produced 6 FP WARNs (3×`non-gjs-scripts` + 3×`script-permissions`) for `tests/run-test.sh`, `tests/generate-references.sh`, `tests/find-target.sh`, `scripts/cloc.sh`, `scripts/clang-format.sh`, and `kwin/build.sh` — all clearly dev tooling.

**Fix:** Add the following exclusions to both `find` calls:
- `*/scripts/*` — build/helper scripts
- `*/tests/*` and `*/test/*` — test runners
- `*/kwin/*` — KWin/Wayland compositor scripts
- `*/docs/*` — documentation generation
- `*/.github/*` — CI/CD workflows (already excluded in some checks)
- `*/ci/*` — CI scripts
- `*/build/*` — build output

These mirror how `node_modules/` and `.git/` are already excluded. Extensions with legitimate pkexec helper scripts (the main exception case) keep their `PASS` result since polkit helpers live in the extension root or a named helper directory, not in `scripts/` or `tests/`.

## Test plan
- [ ] Run ego-lint on Burn My Windows: expect 0 FP WARNs for dev scripts (was 6)
- [ ] Run ego-lint on ddterm: verify no regression (ddterm has no dev scripts at root)
- [ ] Run full test suite: `tests/assertions/` checks should all pass
- [ ] Verify extension with pkexec helper still gets PASS (pkexec helpers not in excluded dirs)