### PR TITLE
fix(ego-lint): add 'downloaded from' keyword to vendored-file detection

### DIFF
--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -260,6 +260,8 @@ _VENDORED_SIGNALS = re.compile(
     r'|@auto-generated\b'
     r'|Credits:\s*https?://'
     r'|Adapted from\s+https?://'
+    r'|[Ww]as downloaded from\s+https?://'
+    r'|[Dd]ownloaded from\s+https?://'
     r')',
     re.IGNORECASE,
 )

--- a/skills/ego-lint/scripts/check-quality.py
+++ b/skills/ego-lint/scripts/check-quality.py
@@ -44,6 +44,8 @@ _VENDORED_SIGNALS = re.compile(
     r'|@auto-generated\b'
     r'|Credits:\s*https?://'
     r'|Adapted from\s+https?://'
+    r'|[Ww]as downloaded from\s+https?://'
+    r'|[Dd]ownloaded from\s+https?://'
     r')',
     re.IGNORECASE,
 )

--- a/tests/assertions/vendored-file-exclusion.sh
+++ b/tests/assertions/vendored-file-exclusion.sh
@@ -7,10 +7,14 @@
 echo "=== vendored-exclusion ==="
 run_lint "vendored-exclusion@test"
 assert_exit_code "exits with 0 (vendored file not flagged)" 0
-# Pattern rules must skip vendored file
+# Pattern rules must skip vendored file (Credits: header)
 assert_output_not_contains "no R-DEPR-09 (var) from vendored file" "\[WARN\].*R-DEPR-09.*css-parser"
-# Quality module-state must skip vendored file
+# Quality module-state must skip vendored file (Credits: header)
 assert_output_not_contains "no quality/module-state from vendored file" "\[WARN\].*quality/module-state.*css-parser"
+# Pattern rules must skip "downloaded from" vendored file (sql-downloaded.js)
+assert_output_not_contains "no R-WEB-03 (fetch) from downloaded-from vendored file" "\[WARN\].*R-WEB-03.*sql-downloaded"
+assert_output_not_contains "no R-WEB-07 (window) from downloaded-from vendored file" "\[WARN\].*R-WEB-07.*sql-downloaded"
+assert_output_not_contains "no prototype-override from downloaded-from vendored file" "\[WARN\].*prototype-override.*sql-downloaded"
 # SKIP notice must be emitted
 assert_output_contains "vendored-file-exclusion SKIP emitted" "\[SKIP\].*vendored-file-exclusion"
 echo ""

--- a/tests/fixtures/vendored-exclusion@test/lib/sql-downloaded.js
+++ b/tests/fixtures/vendored-exclusion@test/lib/sql-downloaded.js
@@ -1,0 +1,12 @@
+/* sql.js - v1.10.2
+ * This file was downloaded from https://github.com/sql-js/sql.js/releases/tag/v1.10.2
+ */
+// Simulates a vendored SQLite WebAssembly port with browser-compat shims.
+// Would trigger R-WEB-03/04/06/07/09 and prototype-override if not excluded.
+
+var fetch = typeof fetch !== 'undefined' ? fetch : null;  // R-WEB-03 trigger
+var XMLHttpRequest = typeof XMLHttpRequest !== 'undefined' ? XMLHttpRequest : null;  // R-WEB-04 trigger
+var window = typeof window !== 'undefined' ? window : null;  // R-WEB-07 trigger
+var document = typeof document !== 'undefined' ? document : null;  // R-WEB-06 trigger
+
+Object.prototype.toString = function() { return '[vendored]'; };  // prototype-override trigger


### PR DESCRIPTION
## Summary

Extends `_VENDORED_SIGNALS` in both `apply-patterns.py` and `check-quality.py` to recognise `downloaded from https://…` and `was downloaded from https://…` comment headers (case-insensitive).

**Root cause:** sql.js v1.10.2 (vendored in Emoji Copy) uses this header:
```
/* SQL.js - v1.10.2
 * This file was downloaded from https://github.com/sql-js/sql.js/releases/tag/v1.10.2
 */
```

This phrase wasn't in the keyword list, so the file was NOT excluded, generating ~47 false positives (R-WEB-03/04/06/07/09, `prototype-override`, `empty-catch`).

## Changes

- `apply-patterns.py`: add `[Ww]as downloaded from\s+https?://` and `[Dd]ownloaded from\s+https?://` to `_VENDORED_SIGNALS`
- `check-quality.py`: same
- `tests/fixtures/vendored-exclusion@test/lib/sql-downloaded.js`: new fixture with `downloaded from` header containing FP-triggering patterns
- `tests/assertions/vendored-file-exclusion.sh`: 3 new assertions for R-WEB-03, R-WEB-07, prototype-override on the new fixture

## Testing

All 7 `vendored-exclusion` assertions pass. No regressions vs. main.