### PR TITLE
fix(ego-lint): suppress quality/module-state FP for conditional import pattern

### DIFF
--- a/skills/ego-lint/scripts/check-quality.py
+++ b/skills/ego-lint/scripts/check-quality.py
@@ -241,6 +241,19 @@ def check_module_state(ext_dir, js_files):
                     )
                     if reset_re.search(content):
                         continue  # Variable is cleaned up
+                    # Carve out: conditional import pattern
+                    # let X; try { X = await import('gi://...') } catch {}
+                    # These are init-only compat imports, not mutable app state.
+                    import_assign_re = re.compile(
+                        rf'\b{re.escape(var_name)}\s*=\s*'
+                        r'(?:\(?\s*await\s+import\s*\(|import\s*\()'
+                    )
+                    if import_assign_re.search(content):
+                        # Verify no non-import assignments exist
+                        stripped = import_assign_re.sub('', content)
+                        other_assign_re = re.compile(rf'\b{re.escape(var_name)}\s*=[^=]')
+                        if not other_assign_re.search(stripped):
+                            continue  # All assignments are from import() — skip
                     found.append(f"{rel}:{i + 1}")
 
     if found:

--- a/tests/fixtures/module-scope-conditional-import@test/LICENSE
+++ b/tests/fixtures/module-scope-conditional-import@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/module-scope-conditional-import@test/extension.js
+++ b/tests/fixtures/module-scope-conditional-import@test/extension.js
@@ -1,0 +1,18 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// GNOME 49+ conditional import — init-only, not mutable app state
+let GioUnix;
+try {
+    GioUnix = (await import('gi://GioUnix?version=2.0')).default;
+} catch {}
+
+export default class ConditionalImportExtension extends Extension {
+    enable() {
+        // GioUnix may be undefined on older GNOME versions
+        if (GioUnix) {
+            // use it
+        }
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/module-scope-conditional-import@test/metadata.json
+++ b/tests/fixtures/module-scope-conditional-import@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "module-scope-conditional-import@test",
+    "name": "Module Scope Conditional Import Test",
+    "description": "Test fixture: conditional import pattern at module scope should not warn",
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
+    "url": "https://example.com"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -172,6 +172,13 @@ assert_output_contains "warns on empty catch" "\[WARN\].*quality/empty-catch"
 assert_output_contains "warns on JSDoc" "\[WARN\].*R-SLOP-01"
 echo ""
 
+# --- module-scope-conditional-import (carve-out: conditional import pattern is not mutable state) ---
+echo "=== module-scope-conditional-import ==="
+run_lint "module-scope-conditional-import@test"
+assert_exit_code "exits with 0 (no issues)" 0
+assert_output_not_contains "no quality/module-state warn for conditional import" "\[WARN\].*quality/module-state"
+echo ""
+
 # --- provenance-jsdoc (provenance post-filter suppresses R-SLOP-01/02) ---
 echo "=== provenance-jsdoc ==="
 run_lint "provenance-jsdoc@test"


### PR DESCRIPTION
## Summary

- `quality/module-state` was incorrectly flagging GNOME 49 conditional import pattern as mutable state
- Adds carve-out: if all assignments to a module-scope `let` variable come from `import()` calls, the WARN is suppressed
- Adds regression test fixture `module-scope-conditional-import@test`

## Root Cause

The check detected `let GioUnix;` at module scope in Caffeine v60's `preferences/appsPage.js:33`. The variable is assigned exactly once via `try { GioUnix = (await import('gi://GioUnix?version=2.0')).default } catch {}` — a standard compat pattern for GNOME 49+. The existing null-reset suppression (`GioUnix = null`) doesn't apply because import-only variables don't need null cleanup.

## Fix

In `check_module_state` (check-quality.py), after the existing null-reset check, a second check strips all `import()`-based assignments from the file content and verifies no other assignments to the variable remain. If so, it's a conditional import — skip.

## Test plan
- [x] `bash tests/run-tests.sh` — 761 tests pass, 0 failures
- [x] `module-scope-conditional-import@test` fixture confirms no WARN for the pattern
- [x] Existing `ai-slop@test` still fires `quality/module-state` for genuine mutable state

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)