### PR TITLE
feat(ego-lint): detect TypeScript source repos with helpful build hint

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -273,7 +273,18 @@ elif [[ -f "$EXT_DIR/src/extension.js" ]]; then
         print_result "FAIL" "file-structure/metadata.json" "metadata.json is missing"
     fi
 else
-    print_result "FAIL" "file-structure/extension.js" "extension.js is missing"
+    # Detect unbuilt TypeScript source repos: .ts files present but no compiled .js
+    _ts_source=false
+    if compgen -G "$EXT_DIR/src/*.ts" > /dev/null 2>&1 || \
+       compgen -G "$EXT_DIR/*.ts" > /dev/null 2>&1; then
+        _ts_source=true
+    fi
+
+    if [[ "$_ts_source" == true ]]; then
+        print_result "FAIL" "file-structure/extension.js" "extension.js is missing — TypeScript source detected; build the extension first (e.g. 'make' or 'npm run build') before running ego-lint|fix: Compile TypeScript source to extension.js before running ego-lint"
+    else
+        print_result "FAIL" "file-structure/extension.js" "extension.js is missing"
+    fi
     if [[ -f "$EXT_DIR/metadata.json" ]]; then
         print_result "PASS" "file-structure/metadata.json" "metadata.json exists"
     elif [[ -f "$EXT_DIR/src/metadata.json" ]]; then

--- a/tests/assertions/typescript-source-detection.sh
+++ b/tests/assertions/typescript-source-detection.sh
@@ -1,0 +1,10 @@
+# TypeScript source repo detection assertions
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_exit_code, etc.
+
+# --- typescript-source-repo (unbuilt .ts files, no extension.js) ---
+echo "=== typescript-source-repo ==="
+run_lint "typescript-source-repo@test"
+assert_exit_code "exits with 1 (blocking issue: missing extension.js)" 1
+assert_output_contains "FAIL with TypeScript hint" "\[FAIL\].*file-structure/extension\.js.*TypeScript source detected"
+assert_output_not_contains "no bare 'extension.js is missing'" "extension\.js is missing$"
+echo ""

--- a/tests/fixtures/typescript-source-repo@test/LICENSE
+++ b/tests/fixtures/typescript-source-repo@test/LICENSE
@@ -1,0 +1,3 @@
+MIT License
+
+Copyright (c) 2024

--- a/tests/fixtures/typescript-source-repo@test/metadata.json
+++ b/tests/fixtures/typescript-source-repo@test/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "TypeScript Extension",
+  "description": "A GNOME extension written in TypeScript",
+  "uuid": "typescript-source-repo@test",
+  "version-name": "1.0.0",
+  "url": "https://github.com/example/typescript-extension",
+  "shell-version": ["47", "48"]
+}

--- a/tests/fixtures/typescript-source-repo@test/src/extension.ts
+++ b/tests/fixtures/typescript-source-repo@test/src/extension.ts
@@ -1,0 +1,12 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+export default class MyExtension {
+    enable(): void {
+        console.log('Extension enabled');
+    }
+    disable(): void {
+        console.log('Extension disabled');
+    }
+}

--- a/tests/fixtures/typescript-source-repo@test/tsconfig.json
+++ b/tests/fixtures/typescript-source-repo@test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- When `extension.js` is missing and `.ts` files are found in `src/` or the extension root, emits a targeted FAIL message: *"TypeScript source detected; build the extension first (e.g. 'make' or 'npm run build') before running ego-lint"*
- Replaces the bare `"extension.js is missing"` message in this case, which gives no actionable guidance to TypeScript extension authors running ego-lint on their dev checkout
- Discovered during field test of Pop Shell (System76 TypeScript tiling extension) against v0.1.17

## Changes

- `skills/ego-lint/scripts/ego-lint.sh` — adds `_ts_source` detection in the else branch of file-structure checks
- `tests/assertions/typescript-source-detection.sh` — 3 new assertions
- `tests/fixtures/typescript-source-repo@test/` — minimal fixture with src/extension.ts, tsconfig.json

## Test results

Net: +2 pass, -2 fail vs. baseline (508/256 → 510/254). All 3 new assertions pass.