### PR TITLE
fix(ego-lint): exclude build script dirs from R-SEC-04 sudo check

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -257,7 +257,7 @@
   message: "sudo is prohibited in GNOME extensions; use pkexec with a polkit policy for privileged operations"
   category: security
   fix: "Replace sudo with pkexec and provide a polkit action file, or use a udev rule for hardware access."
-  exclude-dirs: ["tests", "test"]
+  exclude-dirs: ["tests", "test", "scripts", "docs", ".github", "ci", "build"]
   skip-comments: true
 
 - id: R-SEC-05

--- a/tests/assertions/r-sec-04-build-script.sh
+++ b/tests/assertions/r-sec-04-build-script.sh
@@ -1,0 +1,8 @@
+# R-SEC-04: sudo in build scripts should not fire
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_exit_code, etc.
+
+# --- build-script-sudo (sudo in scripts/ dir is excluded from R-SEC-04) ---
+echo "=== build-script-sudo ==="
+run_lint "build-script-sudo@test"
+assert_output_not_contains "R-SEC-04 not fired on build scripts" "\[FAIL\].*R-SEC-04"
+echo ""

--- a/tests/fixtures/build-script-sudo@test/LICENSE
+++ b/tests/fixtures/build-script-sudo@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/build-script-sudo@test/extension.js
+++ b/tests/fixtures/build-script-sudo@test/extension.js
@@ -1,0 +1,5 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+export default class MyExtension extends Extension {
+  enable() {}
+  disable() {}
+}

--- a/tests/fixtures/build-script-sudo@test/metadata.json
+++ b/tests/fixtures/build-script-sudo@test/metadata.json
@@ -1,0 +1,7 @@
+{
+  "name": "Build Script Sudo Test",
+  "description": "Fixture: sudo in build scripts should not be flagged",
+  "uuid": "build-script-sudo@test",
+  "shell-version": ["46", "47"],
+  "url": "https://example.com"
+}

--- a/tests/fixtures/build-script-sudo@test/scripts/build.sh
+++ b/tests/fixtures/build-script-sudo@test/scripts/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Build script — not part of the installed extension
+sudo make install


### PR DESCRIPTION
## Summary

- Extends `exclude-dirs` for R-SEC-04 (sudo prohibition) to cover dev tooling directories: `scripts`, `docs`, `.github`, `ci`, `build`
- `sudo` in build scripts is normal and should not trigger a GNOME extension security FAIL
- Consistent with the dev-dir exclusion pattern from PR #206 (which excluded these dirs from `non-gjs-scripts` and `script-permissions`)
- Adds fixture `build-script-sudo@test` + assertion to prevent regression

## Test plan
- [x] `bash tests/run-tests.sh` → 762 passed, 0 failed
- [x] Verified: `scripts/rounded_blur_build.sh:52: sudo` on Blur My Shell no longer FAILs R-SEC-04

Closes #215