### PR TITLE
fix(ego-lint): suppress R-SLOP-01/02 JSDoc warnings for TypeScript projects

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -479,6 +479,8 @@
   message: "TypeScript-style JSDoc (@param {Type}) is unusual in GNOME extensions"
   category: ai-slop
   fix: "Remove @param {Type} annotations; GNOME extensions don't use TypeScript-style JSDoc."
+  skip-if-compiled: true
+  skip-if-tsconfig: true
 
 - id: R-SLOP-02
   pattern: "@returns\\s*\\{\\w+\\}"
@@ -487,6 +489,8 @@
   message: "TypeScript-style JSDoc (@returns {Type}) is unusual in GNOME extensions"
   category: ai-slop
   fix: "Remove @returns {Type} annotations; GNOME extensions don't use TypeScript-style JSDoc."
+  skip-if-compiled: true
+  skip-if-tsconfig: true
 
 - id: R-SLOP-05
   pattern: "\"homepage\""

--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -324,6 +324,7 @@ def main():
     shell_versions = _get_shell_versions(ext_dir)
     min_shell = min(shell_versions) if shell_versions else None
     is_compiled_ts = os.environ.get('EGO_LINT_COMPILED_TS') == '1'
+    has_tsconfig = os.environ.get('EGO_LINT_HAS_TSCONFIG') == '1'
 
     # Pre-scan: identify vendored files once and reuse across all rules
     vendored_files = _discover_vendored_files(ext_dir)
@@ -348,6 +349,11 @@ def main():
         # Compiled TypeScript gating: skip rules that flag transpiler artifacts
         if is_compiled_ts and rule.get('skip-if-compiled', '') == 'true':
             print(f"SKIP|{rid}|Not applicable for compiled TypeScript")
+            continue
+
+        # TypeScript project gating: skip rules that produce noise on tsc-compiled output
+        if has_tsconfig and rule.get('skip-if-tsconfig', '') == 'true':
+            print(f"SKIP|{rid}|Not applicable for TypeScript project (tsconfig.json found)")
             continue
 
         if isinstance(scopes, str):

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -245,6 +245,13 @@ else
     print_result "PASS" "compiled-typescript" "No transpiler artifacts detected"
 fi
 
+# TypeScript project detection (tsconfig.json at root or src/)
+# Built TS extensions emit @param {Type} / @returns {Type} annotations from tsc;
+# flagging them as AI slop is noise for maintainers who chose TypeScript.
+if [[ -f "$EXT_DIR/tsconfig.json" || -f "$EXT_DIR/src/tsconfig.json" ]]; then
+    export EGO_LINT_HAS_TSCONFIG=1
+fi
+
 # ---------------------------------------------------------------------------
 # File structure checks
 # ---------------------------------------------------------------------------

--- a/tests/assertions/tsconfig-jsdoc-suppression.sh
+++ b/tests/assertions/tsconfig-jsdoc-suppression.sh
@@ -1,0 +1,12 @@
+# tsconfig.json JSDoc suppression assertions
+# When tsconfig.json is present, R-SLOP-01/02 are suppressed at the pattern level.
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, etc.
+
+echo "=== tsconfig-jsdoc (tsconfig.json suppresses R-SLOP-01/02) ==="
+run_lint "tsconfig-jsdoc@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "R-SLOP-01 suppressed for TS project" "\[WARN\].*R-SLOP-01"
+assert_output_not_contains "R-SLOP-02 suppressed for TS project" "\[WARN\].*R-SLOP-02"
+assert_output_contains "R-SLOP-01 shows as SKIP" "\[SKIP\].*R-SLOP-01.*tsconfig"
+assert_output_contains "R-SLOP-02 shows as SKIP" "\[SKIP\].*R-SLOP-02.*tsconfig"
+echo ""

--- a/tests/fixtures/tsconfig-jsdoc@test/LICENSE
+++ b/tests/fixtures/tsconfig-jsdoc@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/tsconfig-jsdoc@test/extension.js
+++ b/tests/fixtures/tsconfig-jsdoc@test/extension.js
@@ -1,0 +1,21 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+/**
+ * Calculate power percentage.
+ * @param {number} current - current level
+ * @param {number} max - max level
+ * @returns {number} percentage
+ */
+function calcPercent(current, max) {
+    return (current / max) * 100;
+}
+
+export default class TsConfigJsdocExtension extends Extension {
+    enable() {
+        this._value = calcPercent(50, 100);
+    }
+
+    disable() {
+        this._value = null;
+    }
+}

--- a/tests/fixtures/tsconfig-jsdoc@test/metadata.json
+++ b/tests/fixtures/tsconfig-jsdoc@test/metadata.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "tsconfig-jsdoc@test",
+  "name": "TypeScript JSDoc Test",
+  "description": "Test fixture for tsconfig.json JSDoc suppression",
+  "shell-version": ["46"],
+  "version": 1,
+  "url": "https://example.com"
+}

--- a/tests/fixtures/tsconfig-jsdoc@test/tsconfig.json
+++ b/tests/fixtures/tsconfig-jsdoc@test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "outDir": "."
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `skip-if-tsconfig: true` to R-SLOP-01 and R-SLOP-02 in `rules/patterns.yaml`
- Detects `tsconfig.json` at extension root or `src/` in `ego-lint.sh` (`EGO_LINT_HAS_TSCONFIG=1`)
- Implements `skip-if-tsconfig` gating in `apply-patterns.py` — shows `[SKIP]` with "Not applicable for TypeScript project (tsconfig.json found)"
- Also adds `skip-if-compiled: true` to R-SLOP-01 for consistency with R-SLOP-02 and related rules

## Motivation

Forge field test (v0.1.18) revealed that tsc-compiled extensions emit `@param {Type}` / `@returns {Type}` annotations naturally. Flagging these as AI slop is noise for maintainers who chose TypeScript — the annotations come from the compiler, not from an AI assistant.

## Test plan

- [ ] New fixture `tsconfig-jsdoc@test`: extension.js with `@param {Type}` annotations + `tsconfig.json`
- [ ] Assertions: `[SKIP] R-SLOP-01` and `[SKIP] R-SLOP-02` in output; no `[WARN]` for either rule
- [ ] All 507 existing assertions continue to pass

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)