### PR TITLE
fix(ego-lint): suppress R-SLOP-01/02 JSDoc warnings when tsconfig.json is present

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -703,6 +703,11 @@ run_subscript "$SCRIPT_DIR/check-package.sh"
 # (R-SLOP-01/02) are intentional documentation, not AI slop signals. Score 3
 # means strong hand-written indicators (domain vocabulary, nontrivial algorithms).
 # AI-generated code typically scores 1-2. Suppress JSDoc warnings post-hoc.
+#
+# Second path: when tsconfig.json is present at the extension root, the JS
+# output was compiled from TypeScript. tsc preserves @param {Type} annotations
+# verbatim from source, so they are a natural artifact of the TS toolchain —
+# not AI slop. Suppress R-SLOP-01/02 in this case too.
 # Future: move provenance awareness into apply-patterns.py for inline gating.
 
 provenance_score=0
@@ -718,6 +723,13 @@ if [[ "$provenance_score" -ge 3 && "$deferred_count" -gt 0 ]]; then
     WARN_COUNT=$((WARN_COUNT - deferred_count))
     print_result "PASS" "provenance/jsdoc-suppressed" \
         "Suppressed $deferred_count JSDoc warnings (R-SLOP-01/02) — provenance score $provenance_score indicates hand-written code"
+elif [[ -f "$EXT_DIR/tsconfig.json" && "$deferred_count" -gt 0 ]]; then
+    # Suppress deferred R-SLOP-01/02 WARNs for TypeScript-compiled extensions.
+    # tsc preserves JSDoc type annotations from TS source; flagging them is noise
+    # for extension authors who chose TypeScript (e.g. Forge, Pop Shell with tsc).
+    WARN_COUNT=$((WARN_COUNT - deferred_count))
+    print_result "PASS" "tsconfig/jsdoc-suppressed" \
+        "Suppressed $deferred_count JSDoc warnings (R-SLOP-01/02) — tsconfig.json detected, TypeScript-compiled output"
 else
     # Flush deferred entries (low provenance or no deferred entries)
     for entry in "${DEFERRED_SLOP_JSDOC[@]}"; do

--- a/tests/fixtures/tsconfig-jsdoc@test/LICENSE
+++ b/tests/fixtures/tsconfig-jsdoc@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/tsconfig-jsdoc@test/extension.js
+++ b/tests/fixtures/tsconfig-jsdoc@test/extension.js
@@ -1,0 +1,30 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+/**
+ * @param {string} name - The name parameter
+ * @returns {boolean} Whether the operation succeeded
+ */
+function doSomething(name) {
+    return name !== null;
+}
+
+/**
+ * @param {number} value - A numeric value
+ * @param {string} label - A string label
+ * @returns {string} The formatted result
+ */
+function formatValue(value, label) {
+    return `${label}: ${value}`;
+}
+
+export default class TsconfigJsdocExtension extends Extension {
+    enable() {
+        this._result = doSomething('test');
+        this._text = formatValue(42, 'answer');
+    }
+
+    disable() {
+        this._result = null;
+        this._text = null;
+    }
+}

--- a/tests/fixtures/tsconfig-jsdoc@test/metadata.json
+++ b/tests/fixtures/tsconfig-jsdoc@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "tsconfig-jsdoc@test",
+    "name": "TSConfig JSDoc Test",
+    "description": "Tests that R-SLOP-01/02 JSDoc warnings are suppressed when tsconfig.json is present",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}

--- a/tests/fixtures/tsconfig-jsdoc@test/tsconfig.json
+++ b/tests/fixtures/tsconfig-jsdoc@test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "ES2022",
+        "outDir": ".",
+        "strict": true
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -189,6 +189,15 @@ assert_output_not_contains "no R-SLOP-02 WARNs after suppression" "\[WARN\].*R-S
 assert_output_contains "provenance score >= 3" "provenance-score=4"
 echo ""
 
+# --- tsconfig-jsdoc (tsconfig.json presence suppresses R-SLOP-01/02) ---
+echo "=== tsconfig-jsdoc ==="
+run_lint "tsconfig-jsdoc@test"
+assert_exit_code "exits with 0 (warnings only, no failures)" 0
+assert_output_contains "suppresses JSDoc via tsconfig" "\[PASS\].*tsconfig/jsdoc-suppressed"
+assert_output_not_contains "no R-SLOP-01 WARNs after suppression" "\[WARN\].*R-SLOP-01"
+assert_output_not_contains "no R-SLOP-02 WARNs after suppression" "\[WARN\].*R-SLOP-02"
+echo ""
+
 # --- security-patterns ---
 echo "=== security-patterns ==="
 run_lint "security-patterns@test"


### PR DESCRIPTION
## Summary

- TypeScript-compiled GNOME extensions (e.g. Forge, Pop Shell with `tsc`) naturally emit `@param {Type}` and `@returns {Type}` JSDoc annotations in compiled output — preserved verbatim from TypeScript source
- Flagging these as AI slop (R-SLOP-01/02) is noise for TS extension authors; the annotations reflect the TypeScript toolchain, not low code quality
- Adds a second suppression path: when `tsconfig.json` is present at the extension root, R-SLOP-01/02 WARNs are suppressed and `tsconfig/jsdoc-suppressed` PASS is emitted (alongside the existing `provenance-score >= 3` path)

## Background

Field-tested against Forge (a TypeScript-compiled tiling extension with ~200K downloads). R-SLOP-01 was firing on all `@param {Type}` annotations in the compiled JS output. The provenance path did not suppress them because Forge's compiled output scores low on provenance indicators (hand-written domain vocabulary is in TS source, not visible in compiled JS). `tsconfig.json` is the reliable signal that this is a TS-compiled extension.

## Changes

| File | Change |
|------|--------|
| `skills/ego-lint/scripts/ego-lint.sh` | Adds `elif` branch for `tsconfig.json` presence in provenance-gated suppression block |
| `tests/fixtures/tsconfig-jsdoc@test/` | New fixture: extension with `tsconfig.json` + JSDoc annotations, provenance-score=0 |
| `tests/run-tests.sh` | 3 new assertions (exit 0, PASS for `tsconfig/jsdoc-suppressed`, no R-SLOP-01/02 WARNs) |

## Test Results

- Before: 676 passing
- After: 679 passing (+3 new assertions)
- No regressions

Closes #219