### PR TITLE
fix(ego-lint): suppress R-SLOP-01/02 for SPDX-licensed plain JS

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -481,6 +481,7 @@
   fix: "Remove @param {Type} annotations; GNOME extensions don't use TypeScript-style JSDoc."
   skip-if-compiled: true
   skip-if-tsconfig: true
+  skip-if-spdx: true
 
 - id: R-SLOP-02
   pattern: "@returns\\s*\\{\\w+\\}"
@@ -491,6 +492,7 @@
   fix: "Remove @returns {Type} annotations; GNOME extensions don't use TypeScript-style JSDoc."
   skip-if-compiled: true
   skip-if-tsconfig: true
+  skip-if-spdx: true
 
 - id: R-SLOP-05
   pattern: "\"homepage\""

--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -325,6 +325,7 @@ def main():
     min_shell = min(shell_versions) if shell_versions else None
     is_compiled_ts = os.environ.get('EGO_LINT_COMPILED_TS') == '1'
     has_tsconfig = os.environ.get('EGO_LINT_HAS_TSCONFIG') == '1'
+    has_spdx = os.environ.get('EGO_LINT_HAS_SPDX') == '1'
 
     # Pre-scan: identify vendored files once and reuse across all rules
     vendored_files = _discover_vendored_files(ext_dir)
@@ -354,6 +355,11 @@ def main():
         # TypeScript project gating: skip rules that produce noise on tsc-compiled output
         if has_tsconfig and rule.get('skip-if-tsconfig', '') == 'true':
             print(f"SKIP|{rid}|Not applicable for TypeScript project (tsconfig.json found)")
+            continue
+
+        # SPDX license header gating: skip rules that misfire on well-documented plain JS
+        if has_spdx and rule.get('skip-if-spdx', '') == 'true':
+            print(f"SKIP|{rid}|Not applicable for SPDX-licensed project (per-file SPDX headers found)")
             continue
 
         if isinstance(scopes, str):

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -252,6 +252,22 @@ if [[ -f "$EXT_DIR/tsconfig.json" || -f "$EXT_DIR/src/tsconfig.json" ]]; then
     export EGO_LINT_HAS_TSCONFIG=1
 fi
 
+# SPDX license header detection
+# Hand-authored projects with deliberate licensing use SPDX per-file headers.
+# AI-generated code almost never includes SPDX-FileCopyrightText / SPDX-License-Identifier.
+# Threshold: >= 70% of JS files have SPDX headers → suppress R-SLOP-01/02 (intentional JSDoc).
+_spdx_js_total=0
+_spdx_count=0
+while IFS= read -r -d '' _f; do
+    _spdx_js_total=$((_spdx_js_total + 1))
+    if head -n 10 "$_f" 2>/dev/null | grep -qE 'SPDX-(License-Identifier|FileCopyrightText)'; then
+        _spdx_count=$((_spdx_count + 1))
+    fi
+done < <(find "$EXT_DIR" -name "*.js" -not -path "*/node_modules/*" -print0 2>/dev/null)
+if [[ $_spdx_js_total -gt 0 && $((_spdx_count * 100 / _spdx_js_total)) -ge 70 ]]; then
+    export EGO_LINT_HAS_SPDX=1
+fi
+
 # ---------------------------------------------------------------------------
 # File structure checks
 # ---------------------------------------------------------------------------

--- a/tests/assertions/spdx-jsdoc-suppression.sh
+++ b/tests/assertions/spdx-jsdoc-suppression.sh
@@ -1,0 +1,12 @@
+# SPDX license header JSDoc suppression assertions
+# When >= 70% of JS files have SPDX headers, R-SLOP-01/02 are suppressed at the pattern level.
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, etc.
+
+echo "=== spdx-jsdoc (SPDX headers suppress R-SLOP-01/02) ==="
+run_lint "spdx-jsdoc@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "R-SLOP-01 suppressed for SPDX project" "\[WARN\].*R-SLOP-01"
+assert_output_not_contains "R-SLOP-02 suppressed for SPDX project" "\[WARN\].*R-SLOP-02"
+assert_output_contains "R-SLOP-01 shows as SKIP" "\[SKIP\].*R-SLOP-01.*SPDX"
+assert_output_contains "R-SLOP-02 shows as SKIP" "\[SKIP\].*R-SLOP-02.*SPDX"
+echo ""

--- a/tests/fixtures/spdx-jsdoc@test/extension.js
+++ b/tests/fixtures/spdx-jsdoc@test/extension.js
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 Test Author <test@example.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+/**
+ * Calculate brightness as a percentage.
+ * @param {number} current - current brightness value
+ * @param {number} max - maximum brightness value
+ * @returns {number} percentage (0-100)
+ */
+function calcBrightness(current, max) {
+    return (current / max) * 100;
+}
+
+export default class SpdxJsdocExtension extends Extension {
+    enable() {
+        this._brightness = calcBrightness(50, 100);
+    }
+
+    disable() {
+        this._brightness = null;
+    }
+}

--- a/tests/fixtures/spdx-jsdoc@test/metadata.json
+++ b/tests/fixtures/spdx-jsdoc@test/metadata.json
@@ -3,5 +3,5 @@
   "name": "SPDX JSDoc Test",
   "description": "Test fixture: SPDX-licensed plain JS with JSDoc type annotations",
   "shell-version": ["46"],
-  "version": 1
+  "url": "https://github.com/ZviBaratz/gnome-extension-reviewer"
 }

--- a/tests/fixtures/spdx-jsdoc@test/metadata.json
+++ b/tests/fixtures/spdx-jsdoc@test/metadata.json
@@ -1,0 +1,7 @@
+{
+  "uuid": "spdx-jsdoc@test",
+  "name": "SPDX JSDoc Test",
+  "description": "Test fixture: SPDX-licensed plain JS with JSDoc type annotations",
+  "shell-version": ["46"],
+  "version": 1
+}

--- a/tests/fixtures/spdx-jsdoc@test/prefs.js
+++ b/tests/fixtures/spdx-jsdoc@test/prefs.js
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024 Test Author <test@example.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+/**
+ * Build the preferences widget.
+ * @param {object} window - preferences window
+ * @returns {void}
+ */
+export default class SpdxJsdocPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+    }
+}


### PR DESCRIPTION
Closes #226

## What

Adds a third R-SLOP-01/02 suppression path: extensions where >= 70% of JS files carry SPDX license headers (`SPDX-FileCopyrightText` / `SPDX-License-Identifier`) no longer receive JSDoc type annotation warnings.

## Why

Hand-authored projects with deliberate licensing use per-file SPDX headers. AI-generated code virtually never includes these. Night Theme Switcher (rmnvgr/nightthemeswitcher, ~2M EGO downloads, GPL-2.0) was firing 16× false positive R-SLOP-01/02 WARNs despite being a well-maintained, hand-written extension.

The existing provenance-score path requires score >= 3; NTS scores 1 (`consistent-naming-style` only — no hardware/DBus vocabulary, bitwise ops, or debug comments). The tsconfig.json suppression path (v0.1.19) doesn't help — NTS is plain JS.

## How

1. **`ego-lint.sh`**: counts JS files with SPDX headers in their first 10 lines; if coverage >= 70%, sets `EGO_LINT_HAS_SPDX=1`
2. **`apply-patterns.py`**: checks `EGO_LINT_HAS_SPDX` and skips rules with `skip-if-spdx: true`
3. **`rules/patterns.yaml`**: adds `skip-if-spdx: true` to R-SLOP-01 and R-SLOP-02
4. **Test fixture** `spdx-jsdoc@test`: 2 JS files with SPDX headers + JSDoc annotations, verifies both rules show as SKIP

## Suppression paths

| Signal | Path | Added in |
|--------|------|----------|
| `provenance-score >= 3` | `provenance/jsdoc-suppressed` | v0.1.x |
| `tsconfig.json` present | `tsconfig/jsdoc-suppressed` | v0.1.19 |
| SPDX coverage >= 70% | `skip-if-spdx` (SKIP at pattern level) | This PR |