### PR TITLE
fix(ego-lint): suppress EGO download artifacts in metadata checks

### DIFF
--- a/skills/ego-lint/scripts/check-metadata.py
+++ b/skills/ego-lint/scripts/check-metadata.py
@@ -231,6 +231,9 @@ def main():
     elif uuid:
         result("PASS", "metadata/uuid-at-sign", "UUID contains @")
 
+    # Detect EGO-packaged archives (SweetTooth injected _generated key)
+    is_ego_download = "_generated" in meta
+
     # --- Non-standard fields ---
     STANDARD_FIELDS = {
         "uuid", "name", "description", "shell-version",
@@ -242,16 +245,27 @@ def main():
     non_standard = [k for k in meta if k not in STANDARD_FIELDS]
     if non_standard:
         for field in non_standard:
-            result("WARN", "metadata/non-standard-field",
-                   f"'{field}' is not a standard metadata field")
+            if field == "_generated" and is_ego_download:
+                # Injected by EGO's SweetTooth packager — not the extension author's field
+                result("PASS", "metadata/non-standard-field",
+                       "'_generated' suppressed: EGO packaging artifact (SweetTooth injected)")
+            else:
+                result("WARN", "metadata/non-standard-field",
+                       f"'{field}' is not a standard metadata field")
     else:
         result("PASS", "metadata/non-standard-field",
                "No non-standard metadata fields")
 
     # --- Deprecated version field ---
     if "version" in meta:
-        result("WARN", "metadata/deprecated-version",
-               "version field is ignored by EGO for GNOME 45+; remove it (EGO manages versions automatically)")
+        if is_ego_download:
+            result("WARN", "metadata/deprecated-version",
+                   "version field is ignored by EGO for GNOME 45+ "
+                   "(EGO packaging artifact — SweetTooth re-injects this field; "
+                   "check your source repo and remove version if present)")
+        else:
+            result("WARN", "metadata/deprecated-version",
+                   "version field is ignored by EGO for GNOME 45+; remove it (EGO manages versions automatically)")
 
     # --- Missing gettext-domain with locale/ ---
     locale_dir = os.path.join(ext_dir, 'locale')

--- a/tests/fixtures/ego-download-artifact@test/LICENSE
+++ b/tests/fixtures/ego-download-artifact@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/ego-download-artifact@test/extension.js
+++ b/tests/fixtures/ego-download-artifact@test/extension.js
@@ -1,0 +1,1 @@
+// minimal extension

--- a/tests/fixtures/ego-download-artifact@test/metadata.json
+++ b/tests/fixtures/ego-download-artifact@test/metadata.json
@@ -1,0 +1,9 @@
+{
+    "uuid": "ego-download-artifact@test",
+    "name": "EGO Download Artifact Test",
+    "description": "Tests suppression of EGO packaging artifacts",
+    "shell-version": ["48", "49", "50"],
+    "url": "https://github.com/example/test",
+    "version": 42,
+    "_generated": "extensions.gnome.org"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -152,6 +152,13 @@ assert_output_contains "warns on non-standard fields" "\[WARN\].*metadata/non-st
 assert_output_contains "warns on deprecated version" "\[WARN\].*metadata/deprecated-version"
 echo ""
 
+# --- ego-download-artifact ---
+echo "=== ego-download-artifact@test ==="
+run_lint "ego-download-artifact@test"
+assert_output_contains "suppresses _generated field as EGO artifact" "\[PASS\].*metadata/non-standard-field.*_generated.*suppressed"
+assert_output_contains "warns on deprecated-version as EGO artifact" "\[WARN\].*metadata/deprecated-version.*EGO packaging artifact"
+echo ""
+
 # --- bad-package ---
 echo "=== bad-package ==="
 run_lint "bad-package"


### PR DESCRIPTION
## Summary

When EGO's SweetTooth packager downloads an extension, it injects a `_generated` field and re-adds the `version` field into `metadata.json`. These two warnings were noise when field-testing against EGO-downloaded archives (TopHat v23, Caffeine v60 — reproduced in 3+ extensions).

- Detect EGO-packaged archives via presence of `_generated` in metadata
- Suppress `metadata/non-standard-field` WARN for `_generated` (emit PASS noting it's a SweetTooth artifact)
- Annotate `metadata/deprecated-version` WARN to clarify it may be a SweetTooth artifact (message directs author to check their source repo)

Closes #229

## Test plan

- [x] New fixture `ego-download-artifact@test` with `_generated` + `version` in metadata
- [x] 2 new test assertions: PASS on `_generated` suppressed, WARN on deprecated-version with artifact annotation
- [x] 777 tests pass, 0 regressions
- [x] Non-EGO extensions unaffected (non-standard-metadata fixture still warns on `homepage`, `bug-report-url`, `author`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)