### PR TITLE
fix: skip kwin/ subdirectory in JS file traversal (fixes #232)

### DIFF
--- a/skills/ego-lint/scripts/check-accessibility.py
+++ b/skills/ego-lint/scripts/check-accessibility.py
@@ -23,7 +23,7 @@ def result(status, check, detail):
 
 def find_js_files(ext_dir):
     """Find JS files excluding node_modules/.git."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-async.py
+++ b/skills/ego-lint/scripts/check-async.py
@@ -21,7 +21,7 @@ def result(status, check, detail):
 
 def find_js_files(ext_dir, exclude_prefs=True):
     """Find JS files, optionally excluding prefs.js."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-disclosures.py
+++ b/skills/ego-lint/scripts/check-disclosures.py
@@ -21,7 +21,7 @@ def result(status, check, detail):
 
 def find_js_files(ext_dir):
     """Find all JS files in extension directory, excluding node_modules."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-gobject.py
+++ b/skills/ego-lint/scripts/check-gobject.py
@@ -22,7 +22,7 @@ def result(status, check, detail):
 
 def find_js_files(ext_dir):
     """Find all JS files in extension directory, excluding node_modules."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -36,7 +36,7 @@ def strip_comments(content):
 
 def find_js_files(ext_dir):
     """Find all .js files excluding prefs.js and service daemon directories."""
-    skip_dirs = {'node_modules', '.git', '__pycache__', 'service'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'service', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -59,7 +59,7 @@ def result(status, check, detail):
 
 def find_js_files(ext_dir, exclude_prefs=False):
     """Find JS files, optionally excluding prefs.js and preferences directories."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     prefs_dirs = {'preferences', 'prefs'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):

--- a/skills/ego-lint/scripts/check-metadata.py
+++ b/skills/ego-lint/scripts/check-metadata.py
@@ -442,7 +442,7 @@ def check_gettext_domain_consistency(meta, ext_dir):
     if not domain:
         return
 
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     mismatches = []
 
     for root, dirs, files in os.walk(ext_dir):

--- a/skills/ego-lint/scripts/check-polkit.py
+++ b/skills/ego-lint/scripts/check-polkit.py
@@ -21,7 +21,7 @@ def result(status, check, detail):
 
 def find_files(ext_dir, extensions):
     """Find files with given extensions, excluding node_modules/.git."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-quality.py
+++ b/skills/ego-lint/scripts/check-quality.py
@@ -73,7 +73,7 @@ def _is_vendored_file(filepath, scan_lines=30):
 
 def find_js_files(ext_dir):
     """Find all JS files in extension directory, excluding node_modules and vendored files."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/check-schema-usage.py
+++ b/skills/ego-lint/scripts/check-schema-usage.py
@@ -32,7 +32,7 @@ def find_schema_files(ext_dir):
 
 def find_js_files(ext_dir):
     """Find JS files."""
-    skip_dirs = {'node_modules', '.git', '__pycache__'}
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]


### PR DESCRIPTION
## Summary

Fixes #232 — false positives on `quality/module-state`, `quality/lifecycle`, and related checks firing on files inside `kwin/` subdirectories in multi-platform GNOME extensions.

KWin effect scripts run in KDE's JavaScript engine, not GJS. They have no `enable()`/`disable()` lifecycle, no GJS-specific APIs, and no GObject/Shell context. Any GJS-specific advice emitted for these files is inapplicable and misleading to extension authors.

## Fix

Added `'kwin'` to the `skip_dirs` set in `find_js_files()` (and the equivalent `find_files()` in `check-polkit.py`) across all ten JS-scanning check scripts:

- `check-quality.py` (line 76 — the location noted in the issue)
- `check-lifecycle.py`
- `check-accessibility.py`
- `check-async.py`
- `check-disclosures.py`
- `check-gobject.py`
- `check-init.py` (already had `'service'` in skip_dirs; `'kwin'` appended)
- `check-metadata.py` (gettext-domain consistency scan)
- `check-polkit.py`
- `check-schema-usage.py`

## Tests

No regressions: test suite reports the same 521 passed / 256 failed before and after the change. The 256 pre-existing failures are unrelated to this fix (they cover other checks with known open issues).