### PR TITLE
test: add tsconfig-jsdoc suppression assertions for tsconfig-jsdoc@test fixture

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -196,6 +196,14 @@ assert_output_not_contains "no R-SLOP-02 WARNs after suppression" "\[WARN\].*R-S
 assert_output_contains "provenance score >= 3" "provenance-score=4"
 echo ""
 
+# --- tsconfig-jsdoc (skip-if-tsconfig suppresses R-SLOP-01/02 via patterns.yaml) ---
+echo "=== tsconfig-jsdoc ==="
+run_lint "tsconfig-jsdoc@test"
+assert_exit_code "exits with 0 (no issues)" 0
+assert_output_not_contains "no R-SLOP-01 WARNs (tsconfig suppression)" "\[WARN\].*R-SLOP-01"
+assert_output_not_contains "no R-SLOP-02 WARNs (tsconfig suppression)" "\[WARN\].*R-SLOP-02"
+echo ""
+
 # --- security-patterns ---
 echo "=== security-patterns ==="
 run_lint "security-patterns@test"


### PR DESCRIPTION
## Summary

- The `tsconfig-jsdoc@test` fixture was added to main but never wired into `run-tests.sh`
- This PR adds 3 assertions verifying that `skip-if-tsconfig: true` on R-SLOP-01/02 correctly suppresses JSDoc WARNs when `tsconfig.json` is present
- Closes the test gap left by the stale PR #235 (which is now CONFLICTING and redundant — its bash-level suppression path was superseded by the patterns.yaml `skip-if-tsconfig` approach already in main)

## Test

```
=== tsconfig-jsdoc ===
✓ exits with 0 (no issues)
✓ no R-SLOP-01 WARNs (tsconfig suppression)
✓ no R-SLOP-02 WARNs (tsconfig suppression)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)