### PR TITLE
fix(ego-lint): accept settings-schema as namespace prefix in schema/id-matches

### DIFF
--- a/skills/ego-lint/scripts/check-schema.sh
+++ b/skills/ego-lint/scripts/check-schema.sh
@@ -94,7 +94,22 @@ if [[ "$has_settings_schema" == true ]]; then
         fi
     done
     if [[ -z "$primary_schema_file" ]]; then
-        echo "FAIL|schema/id-matches|settings-schema '$settings_schema' not found in any .gschema.xml file"
+        # Check for namespace-prefix pattern: settings-schema used as a prefix
+        # (e.g. metadata says "org.foo.bar" but gschema defines "org.foo.bar.state").
+        # This is valid — the extension builds sub-schema paths by appending suffixes.
+        prefix_match=""
+        for schema_file in "${schema_files[@]}"; do
+            if extract_all_schema_ids "$schema_file" | grep -q "^${settings_schema}\."; then
+                prefix_match="$schema_file"
+                break
+            fi
+        done
+        if [[ -n "$prefix_match" ]]; then
+            echo "PASS|schema/id-matches|settings-schema '$settings_schema' used as namespace prefix — sub-schemas found in $(basename "$prefix_match")"
+            primary_schema_file="$prefix_match"
+        else
+            echo "FAIL|schema/id-matches|settings-schema '$settings_schema' not found in any .gschema.xml file"
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Problem

`schema/id-matches` emits FAIL when `settings-schema` in metadata.json doesn't exactly match any schema ID in gschema.xml, even when all sub-schemas are prefixed by it.

**Example: Space Bar v34** (`space-bar@luchrioh`, 287K EGO downloads)
- `metadata.json`: `"settings-schema": "org.gnome.shell.extensions.space-bar"`
- `gschema.xml` contains: `.state`, `.behavior`, `.appearance`, `.shortcuts` sub-schemas
- Extension code: `this._extension.getSettings(metadata['settings-schema'] + '.state')`

This pattern is legitimate — the extension builds sub-schema paths by appending suffixes to the namespace prefix. The parent schema itself is never instantiated as a GSettings object.

## Fix

When no exact match is found, check whether any schema ID in the gschema.xml starts with `settings_schema + '.'`. If so, emit PASS with a note explaining the namespace prefix pattern was detected.

## Impact

- Space Bar v34: `schema/id-matches` FAIL → PASS (correct)
- No regression on extensions with direct schema ID matches

Closes #238

🤖 Generated with [Claude Code](https://claude.ai/claude-code)