### PR TITLE
fix(ego-lint): use word boundary in GLib.Uri network pattern to prevent GLib.UriFlags FP

### DIFF
--- a/skills/ego-lint/scripts/check-disclosures.py
+++ b/skills/ego-lint/scripts/check-disclosures.py
@@ -43,7 +43,7 @@ CAPABILITY_CHECKS = [
     {
         'name': 'network',
         'code_patterns': [
-            r'Soup\.Session', r'Soup\.Message', r'Soup\.URI', r'GLib\.Uri',
+            r'Soup\.Session', r'Soup\.Message', r'Soup\.URI', r'GLib\.Uri\b',  # word boundary prevents GLib.UriFlags from matching
         ],
         'disclosure_keywords': [
             'network', 'internet', 'http', 'api', 'server',


### PR DESCRIPTION
## Summary

- `GLib.UriFlags.NONE` was matching the `r'GLib\.Uri'` network detection pattern in `check-disclosures.py`, causing a false-positive `disclosure/network` WARN for extensions that load local `.ui` template files via `GLib.uri_resolve_relative(import.meta.url, 'page.ui', GLib.UriFlags.NONE)`.
- Added `\b` word boundary so `GLib.UriFlags` no longer matches while genuine network APIs (`GLib.Uri.parse()`, `GLib.Uri.new_from_string()`) still do.
- All 780 tests pass; no regressions.

Closes #240

## Test plan

- [x] `bash tests/run-tests.sh` — 780 passed, 0 failed
- [x] Field-tested on Rounded Window Corners Reborn (`rounded-window-corners@fxgn`): `disclosure/network` WARN eliminated; `disclosure/file-io` (real: shader file reads) correctly retained