### PR TITLE
fix(ego-lint): add guard-pattern to R-VER46-03 for cairo_set_source_color existence check

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -881,6 +881,7 @@
   category: version-compat
   fix: "Use cr.setSourceColor(color) instead"
   min-version: 46
+  guard-pattern: "\\bif\\s*\\(\\s*Clutter\\.cairo_set_source_color\\b|\\bShellVersion\\b"
   compat-downgrade: true
 
 - id: R-VER46-04


### PR DESCRIPTION
## Problem

R-VER46-03 flags `Clutter.cairo_set_source_color` as a blocking FAIL even when protected by an existence check (`if (Clutter.cairo_set_source_color)`). Found via **Bluetooth-Battery-Meter** field test.

The extension's `colorHelpers.js` uses a proper compatibility shim:

```js
export function setSourceColor(cr, sourceColor) {
    if (Clutter.cairo_set_source_color)      // guard: GNOME ≤45
        Clutter.cairo_set_source_color(cr, sourceColor);
    else
        cr.setSourceColor(sourceColor);      // GNOME 46+
}
```

This is semantically correct — the deprecated API is only called when it exists (GNOME ≤45). The `else` branch handles GNOME 46+. Without the guard-pattern fix, both lines 152 and 153 produce FAIL:

```
[FAIL] R-VER46-03   colorHelpers.js:152: Clutter.cairo_set_source_color() removed in GNOME 46
[FAIL] R-VER46-03   colorHelpers.js:153: Clutter.cairo_set_source_color() removed in GNOME 46
```

## Fix

Add `guard-pattern` to R-VER46-03, matching the R-VER46-01/02 precedent (both of which already suppress `if (obj.add_actor)` / `if (obj.remove_actor)` existence checks):

```yaml
guard-pattern: "\\bif\\s*\\(\\s*Clutter\\.cairo_set_source_color\\b|\\bShellVersion\\b"
```

When the preceding line contains `if (Clutter.cairo_set_source_color)`, the guarded call on the next line is suppressed.

## Testing

- Field test: Bluetooth-Battery-Meter — 2 FP FAILs on `colorHelpers.js:152-153` → resolved with this fix
- No existing tests cover R-VER46-03; guard-pattern behavior is exercised by the R-VER46-01/02 test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)