### PR TITLE
fix(ego-lint): extend metadata build-type guard to handle bracket notation

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -385,7 +385,7 @@ if [[ ${#_console_js_files[@]} -gt 0 ]]; then
             start=$((lineno - 3))
             [[ $start -lt 1 ]] && start=1
             guard=$(sed -n "${start},$((lineno - 1))p" "$f" \
-                | grep -iE "build-type['\"]?\s*[=!]=\s*['\"]debug['\"]|this[._]_?settings[._]DEBUG\b|if\s*\(\s*this[._]_?debug\b" || true)
+                | grep -iE "build-type['\"]?\]?\s*[=!]==?\s*['\"]debug['\"]|this[._]_?settings[._]DEBUG\b|if\s*\(\s*this[._]_?debug\b" || true)
             if [[ -n "$guard" ]]; then
                 console_log_guarded_hits+="  $rel_path: $stripped"$'\n'
             else

--- a/tests/fixtures/console-log-metadata-guard@test/LICENSE
+++ b/tests/fixtures/console-log-metadata-guard@test/LICENSE
@@ -1,0 +1,1 @@
+SPDX-License-Identifier: GPL-2.0-or-later

--- a/tests/fixtures/console-log-metadata-guard@test/debug.js
+++ b/tests/fixtures/console-log-metadata-guard@test/debug.js
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+const metadata = Extension.lookupByURL(import.meta.url)?.metadata ?? {};
+
+export function debugLog(msg) {
+    if (metadata['build-type'] === 'debug')
+        console.log(`[TestExt] ${msg}`);
+}

--- a/tests/fixtures/console-log-metadata-guard@test/extension.js
+++ b/tests/fixtures/console-log-metadata-guard@test/extension.js
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import {debugLog} from './debug.js';
+
+export default class TestExtension extends Extension {
+    enable() {
+        debugLog('enabled');
+    }
+
+    disable() {
+        debugLog('disabled');
+    }
+}

--- a/tests/fixtures/console-log-metadata-guard@test/metadata.json
+++ b/tests/fixtures/console-log-metadata-guard@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "console-log-metadata-guard@test",
+    "name": "Console Log Metadata Guard Test",
+    "description": "Extension with console.log guarded by metadata build-type check",
+    "shell-version": ["46", "47", "48"],
+    "url": "https://github.com/test/console-log-metadata-guard"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -109,6 +109,14 @@ assert_exit_code "exits with 1 (has failures)" 1
 assert_output_contains "fails on console.log" "\[FAIL\].*no-console-log"
 echo ""
 
+# --- console-log-metadata-guard ---
+echo "=== console-log-metadata-guard@test ==="
+run_lint "console-log-metadata-guard@test"
+assert_exit_code "exits with 0 (guarded, no hard failure)" 0
+assert_output_contains "warns on guarded console.log" "\[WARN\].*no-console-log"
+assert_output_not_contains "no FAIL on metadata-guarded console.log" "\[FAIL\].*no-console-log"
+echo ""
+
 # --- deprecated-modules ---
 echo "=== deprecated-modules ==="
 run_lint "deprecated-modules"


### PR DESCRIPTION
## Summary

The `no-console-log` check fires FAIL on extensions that guard `console.log` inside `if (metadata['build-type'] === 'debug')`. Two regex issues caused the FP: the closing `']` after the key wasn't handled, and `[=!]=` only matched `==`/`!=`, not `===`/`!==`.

**Real-world case**: Night Theme Switcher (324K downloads) uses this pattern in `debug.js`. The console.log is dead code in release builds.

## Changes

- `ego-lint.sh`: extend guard regex — add `\]?` (optional bracket) and change `[=!]=` → `[=!]==?` (strict equality)
- `tests/fixtures/console-log-metadata-guard@test/`: new fixture reproducing the pattern
- `tests/run-tests.sh`: assert WARN (not FAIL) on the new fixture

## Test

```
783 passed, 0 failed
```

Closes #247