### PR TITLE
fix(ego-lint): clarify why debug guard is redundant in no-console-log warn

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -402,7 +402,7 @@ if [[ -n "$console_log_hits" ]]; then
 elif [[ -n "$console_log_guarded_hits" ]]; then
     # All console.log calls are behind a debug guard — guarded in production
     hit_count=$(echo -n "$console_log_guarded_hits" | grep -c '.' || true)
-    print_result "WARN" "no-console-log" "Found $hit_count console.log() call(s) behind a debug guard — prefer console.debug() with G_MESSAGES_DEBUG instead"
+    print_result "WARN" "no-console-log" "Found $hit_count console.log() call(s) behind a debug guard — console.debug() is silenced by default and enabled via G_MESSAGES_DEBUG, making the custom guard redundant"
 else
     print_result "PASS" "no-console-log" "No console.log() calls found"
 fi


### PR DESCRIPTION
## Summary

When `console.log()` calls are behind a custom settings-based debug guard, the WARN message now explains that `console.debug()` is silenced by default and enabled via `G_MESSAGES_DEBUG` — making the custom guard redundant. Previously the message only said 'prefer console.debug() with G_MESSAGES_DEBUG', without explaining why the guard itself is unnecessary.

## Changes

- Improved WARN message for settings-guarded `console.log()` calls to clarify the `G_MESSAGES_DEBUG` mechanism

## Test plan

- [x] CI passing on branch (`Tests` 3m6s, green)
- [x] Message quality improvement — no behavior change, no new test fixtures required

## Context

Discovered during Panel Corners field test (2026-04-30): the extension uses `this._debugMode` guarded console.log calls. The old message didn't explain *why* console.debug() makes the custom guard redundant — just that it was preferred.