### PR TITLE
fix(ego-lint): add fix suggestion to no-console-log WARN for guarded calls

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -402,7 +402,7 @@ if [[ -n "$console_log_hits" ]]; then
 elif [[ -n "$console_log_guarded_hits" ]]; then
     # All console.log calls are behind a debug guard — guarded in production
     hit_count=$(echo -n "$console_log_guarded_hits" | grep -c '.' || true)
-    print_result "WARN" "no-console-log" "Found $hit_count console.log() call(s) behind a debug guard — console.debug() is silenced by default and enabled via G_MESSAGES_DEBUG, making the custom guard redundant"
+    print_result "WARN" "no-console-log" "Found $hit_count console.log() call(s) behind a debug guard — console.debug() is silenced by default and enabled via G_MESSAGES_DEBUG, making the custom guard redundant|fix: Replace with console.debug() and remove the custom debug toggle"
 else
     print_result "PASS" "no-console-log" "No console.log() calls found"
 fi


### PR DESCRIPTION
## Summary

When all `console.log()` calls are behind a custom debug guard, the WARN message now includes a fix hint — aligning it with the unguarded-FAIL path which already carries `|fix: Replace with console.debug() — it is silenced by default and enabled via G_MESSAGES_DEBUG, so no custom debug toggle is needed`.

Before:
```
WARN  no-console-log  Found 3 console.log() call(s) behind a debug guard — console.debug() is silenced by default and enabled via G_MESSAGES_DEBUG, making the custom guard redundant
```

After:
```
WARN  no-console-log  Found 3 console.log() call(s) behind a debug guard — console.debug() is silenced by default and enabled via G_MESSAGES_DEBUG, making the custom guard redundant
                      fix: Replace with console.debug() and remove the custom debug toggle
```

## Changes

- One-line change to `skills/ego-lint/scripts/ego-lint.sh`: appended `|fix:` hint to the guarded-WARN `print_result` call

## Context

Identified during field testing of extensions with settings-guarded debug logging (e.g., Panel Corners, Vitals). The FAIL path already had a fix hint; the WARN path was missing it, requiring reviewers to consult docs rather than act inline.

## Test plan

- [ ] CI passing (Tests)
- No behavior change — message format only
- No new test fixtures required (the existing guarded-WARN fixture validates the message; the `|fix:` suffix is rendered but not asserted against in current tests)