### PR TITLE
fix(ego-lint): suppress R-WEB-06 when local variable shadows document global

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -67,6 +67,8 @@
   scope: ["*.js"]
   severity: blocking
   skip-comments: true
+  guard-pattern: "(const|let|var)\\s+document\\s*="
+  guard-window: 100
   message: "DOM APIs (document.*) are not available in GJS"
   category: web-apis
   fix: "GJS has no DOM. Use GObject/Clutter/St/GTK widgets instead."

--- a/tests/fixtures/web-apis/extension.js
+++ b/tests/fixtures/web-apis/extension.js
@@ -15,3 +15,10 @@ export default class WebApisExtension extends Extension {
 
     disable() {}
 }
+
+async function fetchLinkPreview(url) {
+    const document = await parseMetadata(url); // local var — must NOT trigger R-WEB-06
+    const title = document.title;              // local var access — must NOT trigger R-WEB-06
+    const desc = document.description;        // local var access — must NOT trigger R-WEB-06
+    return { title, desc };
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -131,7 +131,7 @@ assert_exit_code "exits with 1 (has failures)" 1
 assert_output_contains "fails on setTimeout" "\[FAIL\].*R-WEB-01"
 assert_output_contains "fails on XMLHttpRequest" "\[FAIL\].*R-WEB-04"
 assert_output_contains "fails on document.*" "\[FAIL\].*R-WEB-06"
-assert_output_count "R-WEB-06 fires exactly once (JSDoc comment skipped)" "\[FAIL\].*R-WEB-06" 1
+assert_output_count "R-WEB-06 fires exactly once (JSDoc skipped, local var guarded)" "\[FAIL\].*R-WEB-06" 1
 assert_output_contains "fails on clearTimeout" "\[FAIL\].*R-WEB-10"
 assert_output_contains "fails on clearInterval" "\[FAIL\].*R-WEB-11"
 echo ""


### PR DESCRIPTION
## Summary

- Adds `guard-pattern` + 100-line lookback to R-WEB-06 to suppress false positives when a local variable named `document` shadows the global DOM object
- Extends `tests/fixtures/web-apis/extension.js` with a local-variable test case (must NOT trigger R-WEB-06)
- Updates test assertion message to reflect dual suppression (JSDoc skip + local var guard)

## Root cause

R-WEB-06 pattern (`\bdocument\.`) fires on any `document.xxx` usage, including local variables. Common in extensions doing link previews, metadata parsing, or working with database record objects named `document`.

Discovered during field test of Pano v21 (`pano@elhan.io`):
```js
const document = await getDocument(trimmedValue); // local var
const title = document.title;      // FP: not DOM API
const desc = document.description; // FP: not DOM API
```

## Fix

Added to `rules/patterns.yaml` for R-WEB-06:
```yaml
guard-pattern: "(const|let|var)\\s+document\\s*="
guard-window: 100
```

The 100-line lookback covers the typical function scope where the local variable is active. Real `document.querySelector(...)` calls without a preceding local declaration still FAIL correctly.

## Test plan

- [x] `bash tests/run-tests.sh` — all assertions pass
- [x] Existing R-WEB-06 assertion fires exactly once (real DOM call at extension.js:11)
- [x] Local variable uses at extension.js:22-24 correctly suppressed
- [x] ego-lint-ignore inline suppression unaffected

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)