### PR TITLE
fix(ego-lint): exclude GJS subprocess directories from pattern checks

### DIFF
--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -304,6 +304,41 @@ def _discover_vendored_files(ext_dir):
     return vendored
 
 
+def _is_subprocess_entry(filepath, scan_lines=2):
+    """Return True if the file is a standalone GJS subprocess (has #!/usr/bin/env gjs shebang)."""
+    try:
+        with open(filepath, encoding='utf-8', errors='replace') as f:
+            for i, line in enumerate(f):
+                if i >= scan_lines:
+                    break
+                if line.startswith('#!') and 'gjs' in line:
+                    return True
+    except OSError:
+        pass
+    return False
+
+
+def _discover_subprocess_dirs(ext_dir):
+    """Return a set of top-level directory names that contain GJS subprocess entry points.
+
+    Extensions like DING bundle a standalone GJS process (with a #!/usr/bin/env gjs
+    shebang) in a subdirectory.  Those files intentionally use legacy CJS-style imports
+    and must not be linted as GNOME Shell extension code.
+    """
+    subprocess_dirs = set()
+    base_skip = ('node_modules', '.git', '__pycache__')
+    for filepath in glob.glob(os.path.join(ext_dir, '**', '*.js'), recursive=True):
+        if not os.path.isfile(filepath):
+            continue
+        rel = os.path.relpath(filepath, ext_dir)
+        parts = rel.split(os.sep)
+        if len(parts) < 2 or parts[0] in base_skip:
+            continue
+        if _is_subprocess_entry(filepath):
+            subprocess_dirs.add(parts[0])
+    return subprocess_dirs
+
+
 def main():
     # Handle --validate mode
     if len(sys.argv) >= 3 and sys.argv[1] == '--validate':
@@ -327,7 +362,13 @@ def main():
     has_tsconfig = os.environ.get('EGO_LINT_HAS_TSCONFIG') == '1'
     has_spdx = os.environ.get('EGO_LINT_HAS_SPDX') == '1'
 
-    # Pre-scan: identify vendored files once and reuse across all rules
+    # Pre-scan: identify subprocess directories and vendored files once, reuse across rules
+    subprocess_dirs = _discover_subprocess_dirs(ext_dir)
+    if subprocess_dirs:
+        dirs_list = ', '.join(sorted(subprocess_dirs))
+        print(f"SKIP|subprocess-dir-exclusion|{len(subprocess_dirs)} top-level dir(s) contain "
+              f"GJS subprocess entry points (#!/usr/bin/env gjs); excluded from pattern rules: {dirs_list}")
+
     vendored_files = _discover_vendored_files(ext_dir)
     if vendored_files:
         files_list = ', '.join(sorted(vendored_files))
@@ -420,9 +461,12 @@ def main():
                 rel = os.path.relpath(filepath, ext_dir)
                 if any(part in skip_dirs for part in rel.split(os.sep)):
                     continue
+                # Skip files in auto-detected GJS subprocess directories
+                rel_parts = rel.replace(os.sep, '/').split('/')
+                if subprocess_dirs and rel_parts[0] in subprocess_dirs:
+                    continue
                 # Skip files in excluded directories (e.g., service daemons)
                 if exclude_dirs:
-                    rel_parts = rel.replace(os.sep, '/').split('/')
                     if rel_parts[0] in exclude_dirs:
                         continue
                 # Skip auto-detected vendored files

--- a/skills/ego-lint/scripts/check-init.py
+++ b/skills/ego-lint/scripts/check-init.py
@@ -34,9 +34,38 @@ def strip_comments(content):
     return content
 
 
+def _discover_subprocess_dirs(ext_dir):
+    """Return top-level dir names that contain GJS subprocess entry points (#!/usr/bin/env gjs)."""
+    subprocess_dirs = set()
+    base_skip = {'node_modules', '.git', '__pycache__'}
+    for root, dirs, filenames in os.walk(ext_dir):
+        dirs[:] = [d for d in dirs if d not in base_skip]
+        rel_root = os.path.relpath(root, ext_dir)
+        parts = rel_root.split(os.sep)
+        if parts[0] == '.':
+            top_dir = None
+        else:
+            top_dir = parts[0]
+        for name in filenames:
+            if not name.endswith('.js'):
+                continue
+            filepath = os.path.join(root, name)
+            try:
+                with open(filepath, encoding='utf-8', errors='replace') as f:
+                    for i, line in enumerate(f):
+                        if i >= 2:
+                            break
+                        if line.startswith('#!') and 'gjs' in line and top_dir:
+                            subprocess_dirs.add(top_dir)
+            except OSError:
+                pass
+    return subprocess_dirs
+
+
 def find_js_files(ext_dir):
     """Find all .js files excluding prefs.js and service daemon directories."""
     skip_dirs = {'node_modules', '.git', '__pycache__', 'service', 'kwin'}
+    skip_dirs |= _discover_subprocess_dirs(ext_dir)
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/tests/assertions/subprocess-dir-exclusion.sh
+++ b/tests/assertions/subprocess-dir-exclusion.sh
@@ -1,0 +1,17 @@
+# Subprocess directory exclusion tests
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_output_not_contains, etc.
+#
+# Verifies that top-level directories containing a GJS subprocess entry point
+# (#!/usr/bin/env gjs shebang) are auto-detected and excluded from pattern rules.
+# Covers the DING (Desktop Icons NG) architecture where app/ bundles a standalone GJS process.
+
+echo "=== subprocess-dir-exclusion ==="
+run_lint "subprocess-dir-exclusion@test"
+assert_exit_code "exits with 0 (subprocess dir not flagged)" 0
+# Legacy imports in app/ subprocess must not produce R-DEPR-04 FAILs
+assert_output_not_contains "no R-DEPR-04 from subprocess dir" "\[FAIL\].*R-DEPR-04.*app"
+# var declarations in app/ subprocess must not produce R-DEPR-09 WARNs
+assert_output_not_contains "no R-DEPR-09 from subprocess dir" "\[WARN\].*R-DEPR-09.*app"
+# SKIP notice must be emitted
+assert_output_contains "subprocess-dir-exclusion SKIP emitted" "\[SKIP\].*subprocess-dir-exclusion"
+echo ""

--- a/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
+++ b/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env gjs
+// Standalone GJS subprocess entry point — runs outside GNOME Shell.
+// Intentionally uses legacy CJS-style imports.
+
+const {Gio, GLib, Gtk} = imports.gi;
+
+var mainWindow = null;
+
+function init() {
+    Gtk.init(null);
+    mainWindow = new Gtk.Window({title: 'Desktop Icons'});
+}

--- a/tests/fixtures/subprocess-dir-exclusion@test/extension.js
+++ b/tests/fixtures/subprocess-dir-exclusion@test/extension.js
@@ -1,0 +1,6 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class SubprocessDirExclusionExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/subprocess-dir-exclusion@test/metadata.json
+++ b/tests/fixtures/subprocess-dir-exclusion@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "subprocess-dir-exclusion@test",
+    "name": "Subprocess Directory Exclusion Test",
+    "description": "Tests that GJS subprocess directories are excluded from pattern rules",
+    "shell-version": ["46", "47", "48", "49", "50"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

Extensions like Desktop Icons NG (DING, ~1.5M EGO downloads) bundle a standalone GJS subprocess in a subdirectory (`app/`). The subprocess entry point uses `#!/usr/bin/env gjs` and the entire directory deliberately uses legacy CJS-style imports (`imports.gi.*`, `var` declarations) — appropriate for code running outside GNOME Shell.

Without this fix, gnome-extension-reviewer would produce:
- **67 blocking R-DEPR-04 FAILs** in `app/*.js` — all false positives
- **~70 advisory R-DEPR-09 WARNs** in `app/*.js` — all false positives

Closes #258.

## Fix

Detect top-level directories containing a GJS subprocess entry point via shebang scanning (`#!/usr/bin/env gjs` in the first two lines of a `.js` file). Exclude all files in those directories from:
- `apply-patterns.py` — pattern rule scans
- `check-init.py` — init-time Shell modification checks

A `SKIP|subprocess-dir-exclusion|...` notice is emitted listing the excluded directory names, consistent with `vendored-file-exclusion`.

**No per-extension configuration required.** The detection is zero-config and mirrors the existing vendored-file-exclusion mechanism.

## Test Results

- 4 new assertions added, all passing
- Baseline: 531 passed / 258 failed → After: 533 passed / 256 failed (net +2 passing, 0 regressions)

## Verification

```
# Clone DING and run
git clone https://gitlab.com/rastersoft/desktop-icons-ng.git
./ego-review desktop-icons-ng/
# Before fix: 67 R-DEPR-04 FAILs in app/
# After fix: SKIP|subprocess-dir-exclusion|1 dir(s)... app; 0 FAILs from app/
```