### PR TITLE
fix(ego-lint): extend subprocess dir exclusion to lifecycle/quality checks

### DIFF
--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -53,6 +53,31 @@ def _skip_non_lifecycle(filepath, ext_dir):
     return any(p in _NON_LIFECYCLE_DIRS for p in parts)
 
 
+def _discover_subprocess_dirs(ext_dir):
+    """Return top-level dir names that contain GJS subprocess entry points (#!/usr/bin/env gjs)."""
+    subprocess_dirs = set()
+    base_skip = {'node_modules', '.git', '__pycache__'}
+    for root, dirs, filenames in os.walk(ext_dir):
+        dirs[:] = [d for d in dirs if d not in base_skip]
+        rel_root = os.path.relpath(root, ext_dir)
+        parts = rel_root.split(os.sep)
+        top_dir = None if parts[0] == '.' else parts[0]
+        for name in filenames:
+            if not name.endswith('.js') or top_dir is None:
+                continue
+            filepath = os.path.join(root, name)
+            try:
+                with open(filepath, encoding='utf-8', errors='replace') as f:
+                    for i, line in enumerate(f):
+                        if i >= 2:
+                            break
+                        if line.startswith('#!') and 'gjs' in line:
+                            subprocess_dirs.add(top_dir)
+            except OSError:
+                pass
+    return subprocess_dirs
+
+
 def result(status, check, detail):
     print(f"{status}|{check}|{detail}")
 
@@ -60,6 +85,7 @@ def result(status, check, detail):
 def find_js_files(ext_dir, exclude_prefs=False):
     """Find JS files, optionally excluding prefs.js and preferences directories."""
     skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
+    skip_dirs |= _discover_subprocess_dirs(ext_dir)
     prefs_dirs = {'preferences', 'prefs'}
     files = []
     for root, dirs, filenames in os.walk(ext_dir):

--- a/skills/ego-lint/scripts/check-quality.py
+++ b/skills/ego-lint/scripts/check-quality.py
@@ -71,9 +71,35 @@ def _is_vendored_file(filepath, scan_lines=30):
     return False
 
 
+def _discover_subprocess_dirs(ext_dir):
+    """Return top-level dir names that contain GJS subprocess entry points (#!/usr/bin/env gjs)."""
+    subprocess_dirs = set()
+    base_skip = {'node_modules', '.git', '__pycache__'}
+    for root, dirs, filenames in os.walk(ext_dir):
+        dirs[:] = [d for d in dirs if d not in base_skip]
+        rel_root = os.path.relpath(root, ext_dir)
+        parts = rel_root.split(os.sep)
+        top_dir = None if parts[0] == '.' else parts[0]
+        for name in filenames:
+            if not name.endswith('.js') or top_dir is None:
+                continue
+            filepath = os.path.join(root, name)
+            try:
+                with open(filepath, encoding='utf-8', errors='replace') as f:
+                    for i, line in enumerate(f):
+                        if i >= 2:
+                            break
+                        if line.startswith('#!') and 'gjs' in line:
+                            subprocess_dirs.add(top_dir)
+            except OSError:
+                pass
+    return subprocess_dirs
+
+
 def find_js_files(ext_dir):
     """Find all JS files in extension directory, excluding node_modules and vendored files."""
     skip_dirs = {'node_modules', '.git', '__pycache__', 'kwin'}
+    skip_dirs |= _discover_subprocess_dirs(ext_dir)
     files = []
     for root, dirs, filenames in os.walk(ext_dir):
         dirs[:] = [d for d in dirs if d not in skip_dirs]

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -269,6 +269,36 @@ if [[ $_spdx_js_total -gt 0 && $((_spdx_count * 100 / _spdx_js_total)) -ge 70 ]]
 fi
 
 # ---------------------------------------------------------------------------
+# Subprocess directory detection
+# ---------------------------------------------------------------------------
+# Top-level dirs containing a GJS subprocess entry point (#!/usr/bin/env gjs)
+# run outside GNOME Shell and must not be checked for Shell-specific patterns.
+# Mirrors the _discover_subprocess_dirs() logic in the Python checks.
+
+_SUBPROCESS_DIRS=()
+while IFS= read -r -d '' f; do
+    rel="${f#"$EXT_DIR/"}"
+    top_dir="${rel%%/*}"
+    [[ "$top_dir" == "$rel" ]] && continue  # root-level file, no subdir
+    if head -n 2 "$f" 2>/dev/null | grep -q '#!/usr/bin/env.*gjs'; then
+        _SUBPROCESS_DIRS+=("$EXT_DIR/$top_dir")
+    fi
+done < <(find "$EXT_DIR" -name '*.js' \
+    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
+
+# Build find exclusion args for use in per-check file discovery
+_SUBPROCESS_EXCL=()
+for _sd in "${_SUBPROCESS_DIRS[@]}"; do
+    _SUBPROCESS_EXCL+=("-not" "-path" "${_sd}/*")
+done
+
+if [[ ${#_SUBPROCESS_DIRS[@]} -gt 0 ]]; then
+    _sd_names=()
+    for _sd in "${_SUBPROCESS_DIRS[@]}"; do _sd_names+=("$(basename "$_sd")/"); done
+    print_result "SKIP" "subprocess-dir-exclusion" "Detected GJS subprocess dir(s): ${_sd_names[*]} — excluded from Shell extension checks"
+fi
+
+# ---------------------------------------------------------------------------
 # File structure checks
 # ---------------------------------------------------------------------------
 
@@ -360,12 +390,14 @@ fi
 
 console_log_hits=""
 console_log_guarded_hits=""
-# Collect all JS files under EXT_DIR, respecting standard exclusions
+# Collect all JS files under EXT_DIR, respecting standard exclusions.
+# Subprocess dirs are excluded — they run outside the Shell extension lifecycle.
 _console_js_files=()
 while IFS= read -r -d '' f; do
     _console_js_files+=("$f")
 done < <(find "$EXT_DIR" -name '*.js' \
-    -not -path '*/node_modules/*' -not -path '*/.git/*' -print0 2>/dev/null)
+    -not -path '*/node_modules/*' -not -path '*/.git/*' \
+    "${_SUBPROCESS_EXCL[@]}" -print0 2>/dev/null)
 
 if [[ ${#_console_js_files[@]} -gt 0 ]]; then
 

--- a/tests/assertions/subprocess-dir-exclusion.sh
+++ b/tests/assertions/subprocess-dir-exclusion.sh
@@ -18,6 +18,8 @@ assert_output_not_contains "no R-DEPR-09 from subprocess dir" "\[WARN\].*R-DEPR-
 assert_output_not_contains "no gsettings-signal-leak from subprocess dir" "\[FAIL\].*gsettings-signal-leak.*app"
 # Quality checks must not fire on subprocess files
 assert_output_not_contains "no quality checks from subprocess dir" "\[FAIL\].*quality/.*app"
+# console.log() in subprocess must not produce no-console-log FAILs
+assert_output_not_contains "no no-console-log FAIL from subprocess dir" "\[FAIL\].*no-console-log"
 # SKIP notice must be emitted
 assert_output_contains "subprocess-dir-exclusion SKIP emitted" "\[SKIP\].*subprocess-dir-exclusion"
 echo ""

--- a/tests/assertions/subprocess-dir-exclusion.sh
+++ b/tests/assertions/subprocess-dir-exclusion.sh
@@ -2,7 +2,9 @@
 # Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_output_not_contains, etc.
 #
 # Verifies that top-level directories containing a GJS subprocess entry point
-# (#!/usr/bin/env gjs shebang) are auto-detected and excluded from pattern rules.
+# (#!/usr/bin/env gjs shebang) are auto-detected and excluded from ALL lint checks:
+# pattern rules (apply-patterns), init checks (check-init), lifecycle checks
+# (check-lifecycle), and quality checks (check-quality).
 # Covers the DING (Desktop Icons NG) architecture where app/ bundles a standalone GJS process.
 
 echo "=== subprocess-dir-exclusion ==="
@@ -12,6 +14,10 @@ assert_exit_code "exits with 0 (subprocess dir not flagged)" 0
 assert_output_not_contains "no R-DEPR-04 from subprocess dir" "\[FAIL\].*R-DEPR-04.*app"
 # var declarations in app/ subprocess must not produce R-DEPR-09 WARNs
 assert_output_not_contains "no R-DEPR-09 from subprocess dir" "\[WARN\].*R-DEPR-09.*app"
+# GSettings.connect() in subprocess must not produce gsettings-signal-leak FAILs
+assert_output_not_contains "no gsettings-signal-leak from subprocess dir" "\[FAIL\].*gsettings-signal-leak.*app"
+# Quality checks must not fire on subprocess files
+assert_output_not_contains "no quality checks from subprocess dir" "\[FAIL\].*quality/.*app"
 # SKIP notice must be emitted
 assert_output_contains "subprocess-dir-exclusion SKIP emitted" "\[SKIP\].*subprocess-dir-exclusion"
 echo ""

--- a/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
+++ b/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
@@ -12,4 +12,6 @@ var _connId = _settings.connect('changed', () => {});
 function init() {
     Gtk.init(null);
     mainWindow = new Gtk.Window({title: 'Desktop Icons'});
+    console.log('subprocess started');
+    console.log('window created');
 }

--- a/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
+++ b/tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env gjs
 // Standalone GJS subprocess entry point — runs outside GNOME Shell.
-// Intentionally uses legacy CJS-style imports.
+// Intentionally uses legacy CJS-style imports and lifecycle patterns that
+// would be flagged as leaks in Shell extension code but are normal here.
 
 const {Gio, GLib, Gtk} = imports.gi;
 
 var mainWindow = null;
+var _settings = new Gio.Settings({schema_id: 'org.desktop.icons'});
+var _connId = _settings.connect('changed', () => {});
 
 function init() {
     Gtk.init(null);


### PR DESCRIPTION
## Summary

Follow-up to #259 — lifecycle and quality checks were not aware of auto-detected GJS subprocess directories, causing FP FAILs on extensions like DING (Desktop Icons NG) that bundle a standalone GJS process.

**Root cause:** `check-lifecycle.py` and `check-quality.py` each have their own `find_js_files()` that only skip `node_modules`, `.git`, `__pycache__`, and `kwin`. They don't call `_discover_subprocess_dirs()`.

**Impact before this fix (DING v84 with #259 applied):**
- 4 FP `gsettings-signal-leak` FAILs from `app/preferences.js`, `app/dbusUtils.js`, `app/autoAr.js`
- 52 FP `dbus-signal-leak` FAILs from `app/desktopGrid.js` + 47 more subprocess files
- Multiple FP `quality/module-state` and `quality/constructor-resources` FAILs

## Changes

- `check-lifecycle.py`: add `_discover_subprocess_dirs()` and merge into `skip_dirs` in `find_js_files()`
- `check-quality.py`: same
- `tests/fixtures/subprocess-dir-exclusion@test/app/subprocess.js`: add `GSettings.connect()` call to give lifecycle assertions something concrete to verify
- `tests/assertions/subprocess-dir-exclusion.sh`: add assertions for `gsettings-signal-leak` and `quality/*` not firing from subprocess dir

## Test plan

- [ ] All existing subprocess-dir-exclusion assertions pass
- [ ] New assertions (`no gsettings-signal-leak from subprocess dir`, `no quality checks from subprocess dir`) pass
- [ ] CI green on this PR

Closes #260. Depends on #259 (targets that branch — stack this after #259 merges).