### PR TITLE
fix(ego-lint): suppress R-VER48-05 for Cogl.SnippetHook ternary guard

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -1007,9 +1007,10 @@
   severity: blocking
   message: "Shell.SnippetHook removed in GNOME 48"
   category: version-compat
-  fix: "Shell.SnippetHook was removed without replacement in GNOME 48"
+  fix: "Replace Shell.SnippetHook with Cogl.SnippetHook (moved in GNOME 48)"
   min-version: 48
   compat-downgrade: true
+  guard-pattern: "Cogl\\.SnippetHook\\s*\\?"
 
 - id: R-VER48-06
   pattern: "\\.get_key_focus\\s*\\("

--- a/tests/fixtures/gnome48-extras@test/extension.js
+++ b/tests/fixtures/gnome48-extras@test/extension.js
@@ -1,4 +1,5 @@
 import Shell from 'gi://Shell';
+import Cogl from 'gi://Cogl';
 import Clutter from 'gi://Clutter';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
@@ -6,6 +7,8 @@ export default class TestExtension extends Extension {
     enable() {
         this._hook = new Shell.SnippetHook();
         const focus = global.stage.get_key_focus();
+        // Ternary version guard: Cogl.SnippetHook available on GNOME 48+
+        const hook = Cogl.SnippetHook ? Cogl.SnippetHook.FRAGMENT : Shell.SnippetHook.FRAGMENT;
     }
     disable() {
         this._hook = null;

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -715,6 +715,7 @@ echo ""
 echo "=== gnome48-extras ==="
 run_lint "gnome48-extras@test"
 assert_output_contains "Should detect Shell.SnippetHook" "\[FAIL\].*R-VER48-05"
+assert_output_not_contains "Should not flag Cogl.SnippetHook ternary guard" "Cogl\.SnippetHook \? Cogl\.SnippetHook"
 assert_output_contains "Should detect get_key_focus" "\[WARN\].*R-VER48-06"
 assert_exit_code "exits with 1 (has failures)" 1
 echo ""


### PR DESCRIPTION
## Problem

Burn-My-Windows v48 contains this ternary version guard in \`src/Shader.js:200\`:

\`\`\`js
Cogl.SnippetHook ? Cogl.SnippetHook.FRAGMENT : Shell.SnippetHook.FRAGMENT,
\`\`\`

\`Shell.SnippetHook\` appears only in the falsy branch — unreachable on GNOME 48+ where \`Cogl.SnippetHook\` is defined. ego-lint flags this as a R-VER48-05 FAIL, which is a false positive.

## Fix

Add \`guard-pattern: "Cogl\\.SnippetHook\\s*\\?"\` to R-VER48-05. The existing guard-pattern mechanism already checks the same line for the guard regex; when \`Cogl.SnippetHook ?\` appears on the same line as \`Shell.SnippetHook\`, the match is suppressed.

Also corrects the rule \`fix\` message: Shell.SnippetHook was **replaced** by \`Cogl.SnippetHook\`, not removed without replacement (per research/guideline-evolution.md).

## Test Results

- \`gnome48-extras@test/extension.js\` updated with the ternary-guarded line
- New assertion: guarded line is NOT flagged
- Existing assertion: unguarded \`new Shell.SnippetHook()\` continues to FAIL
- **530 passed (+1), 256 failed (0 regressions)**