### PR TITLE
fix(ego-lint): base verdict on FAIL count, not warning count

### DIFF
--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -864,10 +864,10 @@ if [[ "$REPORT" == true ]]; then
     echo ""
     echo "--- VERDICT ---"
     UNIQUE_WARN_COUNT=$(grep "^WARN|" "$RESULTS_FILE" | cut -d'|' -f2 | sort -u | wc -l)
-    if [[ $FAIL_COUNT -gt 0 ]]; then
+    if [[ $FAIL_COUNT -ge 3 ]]; then
         echo "  WILL BE REJECTED: $FAIL_COUNT blocking issue(s) found"
-    elif [[ $UNIQUE_WARN_COUNT -gt 8 ]]; then
-        echo "  LIKELY REJECTED: $UNIQUE_WARN_COUNT checks flagged ($WARN_COUNT total findings)"
+    elif [[ $FAIL_COUNT -ge 1 ]]; then
+        echo "  LIKELY REJECTED: $FAIL_COUNT blocking issue(s) found"
     elif [[ $UNIQUE_WARN_COUNT -gt 0 ]]; then
         echo "  MAY PASS WITH COMMENTS: $UNIQUE_WARN_COUNT checks flagged ($WARN_COUNT total findings)"
     else


### PR DESCRIPTION
Closes #266.

## Problem

`LIKELY REJECTED` fired when unique warning check count exceeded 8, regardless of FAIL count. This caused high-quality extensions with 0 FAILs to receive inaccurate rejection verdicts.

**Example (Apps Menu, official GNOME extension):**
```
237 checks — 199 passed, 0 failed, 22 warnings, 16 skipped
LIKELY REJECTED: 16 checks flagged (22 total findings)  ← wrong
```

## Fix

Decouple verdict from warning count; tie it to FAIL count only.

| FAILs | Verdict |
|-------|---------|
| 3+ | `WILL BE REJECTED` |
| 1–2 | `LIKELY REJECTED` |
| 0, warnings > 0 | `MAY PASS WITH COMMENTS` |
| 0, warnings = 0 | `LIKELY TO PASS` |

EGO's automated review rejects extensions based on FAIL-level blocking checks, not WARN-level advisory notices. Warning count now only affects the PASS/MAY PASS distinction.

## Test Results

Apps Menu (0 FAILs, 22 WARNs):
- Before: `LIKELY REJECTED: 16 checks flagged`
- After: `MAY PASS WITH COMMENTS: 16 checks flagged (22 total findings)`