### PR TITLE
fix(ego-lint): suppress _install_version as SweetTooth artifact

### DIFF
--- a/skills/ego-lint/scripts/check-metadata.py
+++ b/skills/ego-lint/scripts/check-metadata.py
@@ -231,8 +231,9 @@ def main():
     elif uuid:
         result("PASS", "metadata/uuid-at-sign", "UUID contains @")
 
-    # Detect EGO-packaged archives (SweetTooth injected _generated key)
-    is_ego_download = "_generated" in meta
+    # Detect EGO-packaged archives (SweetTooth injects _generated and _install_version)
+    SWEETTOOTH_FIELDS = {"_generated", "_install_version"}
+    is_ego_download = bool(meta.keys() & SWEETTOOTH_FIELDS)
 
     # --- Non-standard fields ---
     STANDARD_FIELDS = {
@@ -245,10 +246,10 @@ def main():
     non_standard = [k for k in meta if k not in STANDARD_FIELDS]
     if non_standard:
         for field in non_standard:
-            if field == "_generated" and is_ego_download:
+            if field in SWEETTOOTH_FIELDS and is_ego_download:
                 # Injected by EGO's SweetTooth packager — not the extension author's field
                 result("PASS", "metadata/non-standard-field",
-                       "'_generated' suppressed: EGO packaging artifact (SweetTooth injected)")
+                       f"'{field}' suppressed: EGO packaging artifact (SweetTooth injected)")
             else:
                 result("WARN", "metadata/non-standard-field",
                        f"'{field}' is not a standard metadata field")


### PR DESCRIPTION
## Problem

EGO-downloaded extensions (via SweetTooth, the EGO distribution mechanism) contain two injected fields that the reviewer incorrectly flags as WARN metadata/non-standard-field:

- _generated — already suppressed ✅
- _install_version — not suppressed ❌ → spurious WARN on every EGO download

Additionally, the is_ego_download heuristic only fired on _generated. If SweetTooth omits _generated but includes _install_version, EGO downloads went undetected.

## Fix

- Replace single-field check with a SWEETTOOTH_FIELDS = {"_generated", "_install_version"} set
- is_ego_download = bool(meta.keys() & SWEETTOOTH_FIELDS) — fires on either or both fields
- Non-standard-field loop now suppresses all SWEETTOOTH_FIELDS members when is_ego_download is True

## Test

EGO download (both fields present): both _generated and _install_version emit PASS (suppressed) instead of WARN.
Normal extension (custom field, no SweetTooth fields): custom field still emits WARN as expected.

Closes #271 (partially — uuid-matches-dir noise for EGO downloads tracked in remaining issue scope).