### PR TITLE
fix(ego-lint): exempt self-UUID lookupByUUID from extension interference check

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -287,7 +287,7 @@
   fix: "Remove all telemetry/analytics code. EGO explicitly bans user tracking."
 
 - id: R-SEC-09
-  pattern: "\\b(Main\\.extensionManager|ExtensionManager|lookupByUUID)\\b"
+  pattern: "\\b(Main\\.extensionManager|ExtensionManager)\\b"
   scope: ["*.js"]
   severity: advisory
   message: "Extension system interference is discouraged; modifying other extensions requires justification"

--- a/skills/ego-lint/scripts/check-security.py
+++ b/skills/ego-lint/scripts/check-security.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""check-security.py — UUID-aware extension interference checks.
+
+Usage: check-security.py EXTENSION_DIR
+
+Supplements the pattern-based R-SEC-09 rule with UUID-aware analysis:
+
+  R-SEC-09b: lookupByUUID() called with a UUID other than the extension's own.
+             Self-lookup (for openPreferences(), etc.) is a legitimate pattern
+             and is explicitly exempted.
+
+Output: pipe-delimited lines: STATUS|check-name|detail
+"""
+
+import json
+import os
+import re
+import sys
+
+
+def result(status, check, detail):
+    print(f"{status}|{check}|{detail}")
+
+
+def _get_extension_uuid(ext_dir):
+    """Read uuid from metadata.json. Returns None if not found."""
+    for candidate in (
+        os.path.join(ext_dir, 'metadata.json'),
+        os.path.join(ext_dir, 'src', 'metadata.json'),
+        os.path.join(ext_dir, 'resources', 'metadata.json'),
+    ):
+        if os.path.isfile(candidate):
+            try:
+                with open(candidate, encoding='utf-8') as f:
+                    meta = json.load(f)
+                return meta.get('uuid')
+            except (json.JSONDecodeError, OSError):
+                pass
+    return None
+
+
+def _iter_js_files(ext_dir):
+    skip_dirs = {'node_modules', '.git', '__pycache__', 'examples'}
+    for root, dirs, filenames in os.walk(ext_dir):
+        dirs[:] = [d for d in dirs if d not in skip_dirs]
+        for name in filenames:
+            if name.endswith('.js'):
+                yield os.path.join(root, name)
+
+
+# Matches lookupByUUID('some-uuid@domain') or lookupByUUID("some-uuid@domain")
+_LOOKUP_STATIC_RE = re.compile(
+    r'\blookupByUUID\s*\(\s*([\'"])([^\'"]+)\1\s*\)'
+)
+# Matches lookupByUUID with a non-literal argument (variable or expression)
+_LOOKUP_DYNAMIC_RE = re.compile(
+    r'\blookupByUUID\s*\('
+)
+
+
+def check_lookup_by_uuid(ext_dir, own_uuid):
+    """Check for lookupByUUID calls targeting other extensions.
+
+    Flags:
+    - R-SEC-09b (advisory): lookupByUUID with a UUID that is not the extension's own
+    - Skips: lookupByUUID with the extension's own UUID (self-lookup, e.g. openPreferences)
+    - R-SEC-09b (advisory, dynamic): lookupByUUID with a dynamic argument (can't verify UUID)
+    """
+    found_any = False
+    for filepath in _iter_js_files(ext_dir):
+        rel = os.path.relpath(filepath, ext_dir)
+        try:
+            with open(filepath, encoding='utf-8', errors='replace') as f:
+                lines = f.readlines()
+        except OSError:
+            continue
+
+        # Strip single-line comments for analysis but preserve line numbers
+        for lineno, raw_line in enumerate(lines, 1):
+            # Skip lines that are purely comments
+            stripped = raw_line.lstrip()
+            if stripped.startswith('//'):
+                continue
+
+            # Check inline suppression
+            if 'ego-lint-ignore' in raw_line:
+                m = re.search(r'ego-lint-ignore(?:-next-line)?(?::\s*(\S+))?', raw_line)
+                if m:
+                    specified = m.group(1)
+                    if not specified or specified in ('R-SEC-09', 'R-SEC-09b'):
+                        continue
+
+            # Check previous line for next-line suppression
+            if lineno >= 2 and 'ego-lint-ignore' in lines[lineno - 2]:
+                m = re.search(
+                    r'ego-lint-ignore(?:-next-line)?(?::\s*(\S+))?',
+                    lines[lineno - 2]
+                )
+                if m:
+                    specified = m.group(1)
+                    if not specified or specified in ('R-SEC-09', 'R-SEC-09b'):
+                        continue
+
+            static_match = _LOOKUP_STATIC_RE.search(raw_line)
+            if static_match:
+                called_uuid = static_match.group(2)
+                if own_uuid and called_uuid == own_uuid:
+                    # Self-lookup — legitimate pattern (openPreferences, status check)
+                    continue
+                detail = (
+                    f"{rel}:{lineno}: lookupByUUID('{called_uuid}') — "
+                    "accessing another extension is discouraged; document the justification"
+                )
+                result('WARN', 'R-SEC-09b', detail)
+                found_any = True
+                continue
+
+            # Dynamic argument — can't determine UUID at analysis time
+            if _LOOKUP_DYNAMIC_RE.search(raw_line):
+                detail = (
+                    f"{rel}:{lineno}: lookupByUUID() with dynamic argument — "
+                    "extension system interference is discouraged; document the justification"
+                )
+                result('WARN', 'R-SEC-09b', detail)
+                found_any = True
+
+    if not found_any:
+        result('PASS', 'R-SEC-09b', 'No cross-extension lookupByUUID calls found')
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: check-security.py EXTENSION_DIR", file=sys.stderr)
+        sys.exit(1)
+
+    ext_dir = os.path.realpath(sys.argv[1])
+    if not os.path.isdir(ext_dir):
+        print(f"ERROR: Not a directory: {ext_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    own_uuid = _get_extension_uuid(ext_dir)
+    check_lookup_by_uuid(ext_dir, own_uuid)
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -748,6 +748,11 @@ if [[ -f "$SCRIPT_DIR/check-disclosures.py" ]]; then
     run_subscript "$SCRIPT_DIR/check-disclosures.py"
 fi
 
+# check-security.py (UUID-aware lookupByUUID cross-extension check)
+if [[ -f "$SCRIPT_DIR/check-security.py" ]]; then
+    run_subscript "$SCRIPT_DIR/check-security.py"
+fi
+
 # check-package.sh
 run_subscript "$SCRIPT_DIR/check-package.sh"
 

--- a/tests/assertions/r-sec-09b-lookup-uuid.sh
+++ b/tests/assertions/r-sec-09b-lookup-uuid.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Assertion: R-SEC-09b — UUID-aware lookupByUUID detection
+#
+# Self-lookup (extension calls lookupByUUID with its own UUID) must not
+# produce a warning. Cross-extension lookup must produce R-SEC-09b advisory.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CHECK="$REPO_ROOT/skills/ego-lint/scripts/check-security.py"
+FIXTURES="$REPO_ROOT/tests/fixtures"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+# --- Test 1: self-lookup must not be flagged ---
+out=$(python3 "$CHECK" "$FIXTURES/lookup-self@test" 2>&1)
+if echo "$out" | grep -q "R-SEC-09b.*extension.js"; then
+    fail "Self-lookup was flagged as R-SEC-09b (false positive)"
+fi
+if echo "$out" | grep -q "^PASS|R-SEC-09b"; then
+    pass "Self-lookup correctly produces no warning"
+else
+    fail "Unexpected output for self-lookup fixture: $out"
+fi
+
+# --- Test 2: cross-extension lookup must be flagged ---
+out=$(python3 "$CHECK" "$FIXTURES/lookup-other@test" 2>&1)
+if echo "$out" | grep -q "WARN|R-SEC-09b"; then
+    pass "Cross-extension lookup correctly flagged as R-SEC-09b"
+else
+    fail "Cross-extension lookup was not flagged: $out"
+fi
+if echo "$out" | grep -q "other-extension@example.com"; then
+    pass "Warning includes the cross-extension UUID for context"
+else
+    fail "Warning does not include the target UUID: $out"
+fi
+
+echo "All R-SEC-09b assertions passed."

--- a/tests/fixtures/lookup-other@test/extension.js
+++ b/tests/fixtures/lookup-other@test/extension.js
@@ -1,0 +1,11 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class LookupOtherExtension extends Extension {
+    enable() {
+        // Cross-extension lookup — should be flagged
+        const other = Extension.lookupByUUID('other-extension@example.com');
+        other?.someMethod();
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/lookup-other@test/metadata.json
+++ b/tests/fixtures/lookup-other@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "lookup-other@test",
+    "name": "Cross Extension Lookup Test",
+    "description": "Tests that cross-extension lookupByUUID is flagged",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}

--- a/tests/fixtures/lookup-self@test/extension.js
+++ b/tests/fixtures/lookup-self@test/extension.js
@@ -1,0 +1,11 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class LookupSelfExtension extends Extension {
+    enable() {
+        // Self-lookup for openPreferences from a menu button — legitimate pattern
+        const self = Extension.lookupByUUID('lookup-self@test');
+        self?.openPreferences();
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/lookup-self@test/metadata.json
+++ b/tests/fixtures/lookup-self@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "lookup-self@test",
+    "name": "Self Lookup Test",
+    "description": "Tests that self-UUID lookupByUUID is not flagged",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

R-SEC-09 flagged any `lookupByUUID()` call, including the legitimate pattern where an extension looks up **itself** to call `openPreferences()` from a menu button. Discovered as a false positive on TopHat v24 during field testing.

**Example false positive** (`monitor.js:212` in TopHat v24):
```js
const obj = Extension.lookupByUUID('tophat@fflewddur.github.io');
obj?.openPreferences();
```
TopHat's own UUID is `tophat@fflewddur.github.io` — this is self-lookup, not cross-extension interference.

## Fix

Split the `lookupByUUID` check from the pattern-based R-SEC-09 into a new Python check (`check-security.py`, rule `R-SEC-09b`) that:

1. Reads the extension's own UUID from `metadata.json`
2. Skips `lookupByUUID` calls where the UUID literal matches the extension's own UUID
3. Still flags `lookupByUUID` with a **different** UUID (cross-extension interference — real concern)
4. Still flags `lookupByUUID` with a **dynamic argument** (can't verify at analysis time)

R-SEC-09 in `patterns.yaml` is updated to cover only `Main.extensionManager|ExtensionManager` (the checks that don't have UUID-context ambiguity).

## Test Results

New assertion: `tests/assertions/r-sec-09b-lookup-uuid.sh`
- Self-lookup fixture → `PASS|R-SEC-09b|No cross-extension lookupByUUID calls found` ✅
- Cross-extension fixture → `WARN|R-SEC-09b|extension.js:6: lookupByUUID('other-extension@example.com') — ...` ✅

Closes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)