### PR TITLE
fix(ego-lint): exclude dev-tooling dirs (gulp/, conf/) from pattern and script checks

### DIFF
--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -304,6 +304,39 @@ def _discover_vendored_files(ext_dir):
     return vendored
 
 
+def _discover_dev_tool_dirs(ext_dir):
+    """Return a set of top-level directory names that are dev-tooling infrastructure.
+
+    These directories exist in source repos but are never shipped in an EGO package —
+    they contain Vagrant VM scripts, Gulp build tasks, and similar dev-only code.
+    Detection is trigger-file-based to avoid excluding legitimate extension subdirs
+    that happen to share common names (e.g. an extension with a real conf/ subdir).
+    """
+    dev_dirs = set()
+
+    # Vagrantfile at root → Vagrant-based dev setup; companion dirs are dev tooling
+    if os.path.isfile(os.path.join(ext_dir, 'Vagrantfile')):
+        for d in ('gulp', 'conf', 'vagrant'):
+            if os.path.isdir(os.path.join(ext_dir, d)):
+                dev_dirs.add(d)
+
+    # gulpfile.js / Gulpfile.js at root → gulp/ is a dev-task directory
+    for gulpfile in ('gulpfile.js', 'Gulpfile.js', 'gulpfile.mjs', 'Gulpfile.mjs'):
+        if os.path.isfile(os.path.join(ext_dir, gulpfile)):
+            if os.path.isdir(os.path.join(ext_dir, 'gulp')):
+                dev_dirs.add('gulp')
+            break
+
+    # Gruntfile.js at root → grunt/ is a dev-task directory
+    for gruntfile in ('Gruntfile.js', 'Gruntfile'):
+        if os.path.isfile(os.path.join(ext_dir, gruntfile)):
+            if os.path.isdir(os.path.join(ext_dir, 'grunt')):
+                dev_dirs.add('grunt')
+            break
+
+    return dev_dirs
+
+
 def _is_subprocess_entry(filepath, scan_lines=2):
     """Return True if the file is a standalone GJS subprocess (has #!/usr/bin/env gjs shebang)."""
     try:
@@ -362,7 +395,7 @@ def main():
     has_tsconfig = os.environ.get('EGO_LINT_HAS_TSCONFIG') == '1'
     has_spdx = os.environ.get('EGO_LINT_HAS_SPDX') == '1'
 
-    # Pre-scan: identify subprocess directories and vendored files once, reuse across rules
+    # Pre-scan: identify subprocess directories, vendored files, and dev-tool dirs once
     subprocess_dirs = _discover_subprocess_dirs(ext_dir)
     if subprocess_dirs:
         dirs_list = ', '.join(sorted(subprocess_dirs))
@@ -374,6 +407,12 @@ def main():
         files_list = ', '.join(sorted(vendored_files))
         print(f"SKIP|vendored-file-exclusion|{len(vendored_files)} file(s) auto-detected as "
               f"vendored (third-party attribution header); excluded from pattern rules: {files_list}")
+
+    dev_tool_dirs = _discover_dev_tool_dirs(ext_dir)
+    if dev_tool_dirs:
+        dirs_list = ', '.join(sorted(dev_tool_dirs))
+        print(f"SKIP|dev-tooling-dir-exclusion|{len(dev_tool_dirs)} top-level dir(s) detected as "
+              f"dev-tooling infrastructure (Vagrantfile/gulpfile trigger); excluded from pattern rules: {dirs_list}")
 
     for rule in rules:
         rid = rule.get('id', '?')
@@ -464,6 +503,9 @@ def main():
                 # Skip files in auto-detected GJS subprocess directories
                 rel_parts = rel.replace(os.sep, '/').split('/')
                 if subprocess_dirs and rel_parts[0] in subprocess_dirs:
+                    continue
+                # Skip files in auto-detected dev-tooling directories (Vagrant/Gulp infra)
+                if dev_tool_dirs and rel_parts[0] in dev_tool_dirs:
                     continue
                 # Skip files in excluded directories (e.g., service daemons)
                 if exclude_dirs:

--- a/skills/ego-lint/scripts/ego-lint.sh
+++ b/skills/ego-lint/scripts/ego-lint.sh
@@ -521,6 +521,7 @@ done < <(find "$EXT_DIR" -type f \( -name '*.py' -o -name '*.sh' -o -name '*.rb'
     -not -path "$EXT_DIR/scripts/*" -not -path "$EXT_DIR/tests/*" -not -path "$EXT_DIR/test/*" \
     -not -path "$EXT_DIR/kwin/*" -not -path "$EXT_DIR/docs/*" -not -path "$EXT_DIR/.github/*" \
     -not -path "$EXT_DIR/ci/*" -not -path "$EXT_DIR/build/*" \
+    -not -path "$EXT_DIR/gulp/*" -not -path "$EXT_DIR/conf/*" -not -path "$EXT_DIR/grunt/*" \
     -print0 2>/dev/null)
 
 if [[ -n "$non_gjs_scripts" ]]; then
@@ -557,6 +558,7 @@ done < <(find "$EXT_DIR" -type f -name '*.sh' \
     -not -path "$EXT_DIR/scripts/*" -not -path "$EXT_DIR/tests/*" -not -path "$EXT_DIR/test/*" \
     -not -path "$EXT_DIR/kwin/*" -not -path "$EXT_DIR/docs/*" -not -path "$EXT_DIR/.github/*" \
     -not -path "$EXT_DIR/ci/*" -not -path "$EXT_DIR/build/*" \
+    -not -path "$EXT_DIR/gulp/*" -not -path "$EXT_DIR/conf/*" -not -path "$EXT_DIR/grunt/*" \
     -print0 2>/dev/null)
 
 if [[ -n "$non_exec_scripts" ]]; then

--- a/tests/assertions/dev-tooling-dir-exclusion.sh
+++ b/tests/assertions/dev-tooling-dir-exclusion.sh
@@ -1,0 +1,23 @@
+# Dev-tooling directory exclusion tests
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_output_not_contains, etc.
+#
+# Verifies that top-level directories containing Vagrant/Gulp development infrastructure
+# are auto-detected (via Vagrantfile trigger) and excluded from pattern rules and
+# non-gjs-scripts / script-permissions checks.
+# Covers the rounded-window-corners pattern where gulp/ and conf/ hold dev tooling
+# that is never shipped in an EGO package.
+
+echo "=== dev-tooling-exclusion ==="
+run_lint "dev-tooling-exclusion@test"
+assert_exit_code "exits with 0 (dev-tooling dirs not flagged)" 0
+# R-SEC-04 (sudo) must not fire from gulp/vagrant.js
+assert_output_not_contains "no R-SEC-04 from gulp/ dir" "\[WARN\].*R-SEC-04.*gulp"
+# R-SEC-22 (gsettings) must not fire from gulp/vagrant.js
+assert_output_not_contains "no R-SEC-22 from gulp/ dir" "\[WARN\].*R-SEC-22.*gulp"
+# non-gjs-scripts must not flag conf/init_vm.sh
+assert_output_not_contains "no non-gjs-scripts WARN" "\[WARN\].*non-gjs-scripts"
+# script-permissions must not flag conf/init_vm.sh
+assert_output_not_contains "no script-permissions WARN" "\[WARN\].*script-permissions"
+# SKIP notice must be emitted for dev-tooling dirs
+assert_output_contains "dev-tooling-dir-exclusion SKIP emitted" "\[SKIP\].*dev-tooling-dir-exclusion"
+echo ""

--- a/tests/fixtures/dev-tooling-exclusion@test/Vagrantfile
+++ b/tests/fixtures/dev-tooling-exclusion@test/Vagrantfile
@@ -1,0 +1,6 @@
+# Vagrant configuration for development VM
+# This file triggers dev-tooling dir detection in ego-lint
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+  config.vm.provision "shell", path: "conf/init_vm.sh"
+end

--- a/tests/fixtures/dev-tooling-exclusion@test/conf/init_vm.sh
+++ b/tests/fixtures/dev-tooling-exclusion@test/conf/init_vm.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# VM initialization script — dev tooling, never shipped in EGO package.
+apt-get update -y
+apt-get install -y gnome-shell-extensions

--- a/tests/fixtures/dev-tooling-exclusion@test/extension.js
+++ b/tests/fixtures/dev-tooling-exclusion@test/extension.js
@@ -1,0 +1,6 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class MyExtension extends Extension {
+    enable() {}
+    disable() {}
+}

--- a/tests/fixtures/dev-tooling-exclusion@test/gulp/vagrant.js
+++ b/tests/fixtures/dev-tooling-exclusion@test/gulp/vagrant.js
@@ -1,0 +1,14 @@
+// Gulp tasks for managing the Vagrant development VM
+// This file is dev tooling — never shipped in an EGO package.
+const gulp = require('gulp');
+const { exec } = require('child_process');
+
+gulp.task('vm-up', (done) => {
+    exec('sudo vagrant up', (err, stdout) => {
+        done(err);
+    });
+});
+
+gulp.task('vm-gsettings', (done) => {
+    exec('gsettings set org.gnome.shell disable-user-extensions false', done);
+});

--- a/tests/fixtures/dev-tooling-exclusion@test/metadata.json
+++ b/tests/fixtures/dev-tooling-exclusion@test/metadata.json
@@ -1,0 +1,8 @@
+{
+  "uuid": "dev-tooling-exclusion@test",
+  "name": "Dev Tooling Exclusion Test",
+  "description": "Fixture for testing dev-tooling directory exclusion (gulp/, conf/).",
+  "version": "1",
+  "shell-version": ["46", "47", "48"],
+  "url": "https://example.com"
+}


### PR DESCRIPTION
Fixes FPs when linting GitHub source repos with Vagrant dev setups (e.g. rounded-window-corners). Adds trigger-file-based dev-tooling dir detection to apply-patterns.py and find exclusions to ego-lint.sh. +4 assertions, 0 regressions.