### PR TITLE
fix(ego-lint): exclude root-level dev-tooling trigger files from pattern checks

### DIFF
--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -305,36 +305,43 @@ def _discover_vendored_files(ext_dir):
 
 
 def _discover_dev_tool_dirs(ext_dir):
-    """Return a set of top-level directory names that are dev-tooling infrastructure.
+    """Return (dev_dirs, dev_trigger_files) for dev-tooling infrastructure at the root.
 
-    These directories exist in source repos but are never shipped in an EGO package —
-    they contain Vagrant VM scripts, Gulp build tasks, and similar dev-only code.
+    dev_dirs: set of top-level directory names that are dev-tooling (e.g. gulp/, conf/).
+    dev_trigger_files: set of root-level filenames that are themselves dev-tooling
+      artifacts (e.g. gulpfile.js, Vagrantfile) and must not be linted as GJS code.
+
+    These files/dirs exist in source repos but are never shipped in an EGO package.
     Detection is trigger-file-based to avoid excluding legitimate extension subdirs
     that happen to share common names (e.g. an extension with a real conf/ subdir).
     """
     dev_dirs = set()
+    dev_trigger_files = set()
 
     # Vagrantfile at root → Vagrant-based dev setup; companion dirs are dev tooling
     if os.path.isfile(os.path.join(ext_dir, 'Vagrantfile')):
+        dev_trigger_files.add('Vagrantfile')
         for d in ('gulp', 'conf', 'vagrant'):
             if os.path.isdir(os.path.join(ext_dir, d)):
                 dev_dirs.add(d)
 
-    # gulpfile.js / Gulpfile.js at root → gulp/ is a dev-task directory
+    # gulpfile.js / Gulpfile.js at root → trigger file + gulp/ is a dev-task directory
     for gulpfile in ('gulpfile.js', 'Gulpfile.js', 'gulpfile.mjs', 'Gulpfile.mjs'):
         if os.path.isfile(os.path.join(ext_dir, gulpfile)):
+            dev_trigger_files.add(gulpfile)
             if os.path.isdir(os.path.join(ext_dir, 'gulp')):
                 dev_dirs.add('gulp')
             break
 
-    # Gruntfile.js at root → grunt/ is a dev-task directory
+    # Gruntfile.js at root → trigger file + grunt/ is a dev-task directory
     for gruntfile in ('Gruntfile.js', 'Gruntfile'):
         if os.path.isfile(os.path.join(ext_dir, gruntfile)):
+            dev_trigger_files.add(gruntfile)
             if os.path.isdir(os.path.join(ext_dir, 'grunt')):
                 dev_dirs.add('grunt')
             break
 
-    return dev_dirs
+    return dev_dirs, dev_trigger_files
 
 
 def _is_subprocess_entry(filepath, scan_lines=2):
@@ -408,11 +415,15 @@ def main():
         print(f"SKIP|vendored-file-exclusion|{len(vendored_files)} file(s) auto-detected as "
               f"vendored (third-party attribution header); excluded from pattern rules: {files_list}")
 
-    dev_tool_dirs = _discover_dev_tool_dirs(ext_dir)
-    if dev_tool_dirs:
-        dirs_list = ', '.join(sorted(dev_tool_dirs))
-        print(f"SKIP|dev-tooling-dir-exclusion|{len(dev_tool_dirs)} top-level dir(s) detected as "
-              f"dev-tooling infrastructure (Vagrantfile/gulpfile trigger); excluded from pattern rules: {dirs_list}")
+    dev_tool_dirs, dev_tool_trigger_files = _discover_dev_tool_dirs(ext_dir)
+    if dev_tool_dirs or dev_tool_trigger_files:
+        parts = []
+        if dev_tool_dirs:
+            parts.append(f"dirs: {', '.join(sorted(dev_tool_dirs))}")
+        if dev_tool_trigger_files:
+            parts.append(f"trigger files: {', '.join(sorted(dev_tool_trigger_files))}")
+        print(f"SKIP|dev-tooling-dir-exclusion|dev-tooling infrastructure detected; excluded from pattern rules: "
+              f"{'; '.join(parts)}")
 
     for rule in rules:
         rid = rule.get('id', '?')
@@ -506,6 +517,9 @@ def main():
                     continue
                 # Skip files in auto-detected dev-tooling directories (Vagrant/Gulp infra)
                 if dev_tool_dirs and rel_parts[0] in dev_tool_dirs:
+                    continue
+                # Skip root-level dev-tooling trigger files (gulpfile.js, Gruntfile.js, Vagrantfile)
+                if dev_tool_trigger_files and len(rel_parts) == 1 and rel_parts[0] in dev_tool_trigger_files:
                     continue
                 # Skip files in excluded directories (e.g., service daemons)
                 if exclude_dirs:

--- a/tests/assertions/dev-tooling-dir-exclusion.sh
+++ b/tests/assertions/dev-tooling-dir-exclusion.sh
@@ -20,4 +20,7 @@ assert_output_not_contains "no non-gjs-scripts WARN" "\[WARN\].*non-gjs-scripts"
 assert_output_not_contains "no script-permissions WARN" "\[WARN\].*script-permissions"
 # SKIP notice must be emitted for dev-tooling dirs
 assert_output_contains "dev-tooling-dir-exclusion SKIP emitted" "\[SKIP\].*dev-tooling-dir-exclusion"
+# R-WEB-09 (require() Node.js) must not fire from root-level gulpfile.js
+assert_output_not_contains "no R-WEB-09 from gulpfile.js" "\[WARN\].*R-WEB-09.*gulpfile"
+assert_output_not_contains "no R-WEB-09 from gulpfile.js (FAIL)" "\[FAIL\].*R-WEB-09.*gulpfile"
 echo ""

--- a/tests/fixtures/dev-tooling-exclusion@test/gulpfile.js
+++ b/tests/fixtures/dev-tooling-exclusion@test/gulpfile.js
@@ -1,0 +1,6 @@
+// This file is a dev-tooling trigger — it is not GJS extension code.
+// gulp/ and conf/ companion dirs are excluded by PR #275; this file itself
+// should also be excluded from pattern checks (R-WEB-09 etc.).
+const gulp = require('gulp');
+const sass = require('gulp-sass');
+const exec = require('child_process').exec;


### PR DESCRIPTION
## Problem

PR #275 excluded companion directories (gulp/, conf/) but left the trigger files themselves (gulpfile.js, Gruntfile.js, Vagrantfile) subject to pattern checks.

**Reproduced on rounded-window-corners with PR #275 branch (issue #277):**
```
✗ R-WEB-09: gulpfile.js:1: require() is Node.js; use ESM imports
✗ R-WEB-09: gulpfile.js:2: require() is Node.js; use ESM imports
... (6 total)
```

`gulpfile.js` is a Node.js build runner — never shipped in an EGO package. These are false positives.

## Fix

`_discover_dev_tool_dirs` now returns `(dev_dirs, dev_trigger_files)`:

- `dev_dirs`: existing set of companion directory names (gulp/, conf/, etc.)
- `dev_trigger_files`: new set of root-level trigger filenames (gulpfile.js, Gruntfile.js, Vagrantfile)

Root-level trigger files are skipped in the file scan loop via a `len(rel_parts) == 1 and rel_parts[0] in dev_tool_trigger_files` guard.

## Test Results

Added `gulpfile.js` with Node.js `require()` calls to the `dev-tooling-exclusion@test` fixture. Added 2 assertions verifying no R-WEB-09 fires.

| Metric | Before | After |
|--------|--------|-------|
| Tests passing | 542 | 545 (+3) |
| Tests failing | 257 | 256 (-1) |

Closes #277