### PR TITLE
fix(ego-lint): accept named default export syntax for R-FILE-07 and R-PREFS-02

### DIFF
--- a/skills/ego-lint/scripts/check-lifecycle.py
+++ b/skills/ego-lint/scripts/check-lifecycle.py
@@ -128,7 +128,22 @@ def _resolve_local_parent_content(ext_dir, content):
     # Find 'export default class extends NAMESPACE.Something'
     m = re.search(r'export\s+default\s+class\b[^{]*\bextends\s+(\w+)\.', content)
     if not m:
-        return None
+        # Also handle: export { MyClass as default }
+        # In this case find the class definition separately
+        named_export = re.search(r'\bexport\s*\{[^}]*\bas\s+default\b', content)
+        if not named_export:
+            return None
+        # Extract the exported name to find its class definition
+        named_m = re.search(r'\bexport\s*\{\s*(\w+)\s+as\s+default\b', content)
+        if not named_m:
+            return None
+        class_name = named_m.group(1)
+        m = re.search(
+            rf'class\s+{re.escape(class_name)}\b[^{{]*\bextends\s+(\w+)\.',
+            content,
+        )
+        if not m:
+            return None
     namespace = m.group(1)
     # Find 'import * as NAMESPACE from './local.js''
     imp = re.search(
@@ -179,7 +194,11 @@ def check_default_export(ext_dir):
         return
 
     content = strip_comments(read_file(ext_js))
-    if not re.search(r'\bexport\s+default\s+class\b', content):
+    has_default_export = bool(
+        re.search(r'\bexport\s+default\s+class\b', content)
+        or re.search(r'\bexport\s*\{[^}]*\bas\s+default\b', content)
+    )
+    if not has_default_export:
         result("WARN", "lifecycle/default-export",
                "extension.js missing 'export default class' — required for GNOME 45+")
     else:

--- a/skills/ego-lint/scripts/check-prefs.py
+++ b/skills/ego-lint/scripts/check-prefs.py
@@ -43,7 +43,20 @@ def _resolve_local_parent_content(prefs_dir, content):
     """
     m = re.search(r'export\s+default\s+class\b[^{]*\bextends\s+(\w+)\.', content)
     if not m:
-        return None
+        # Also handle: export { MyClass as default }
+        named_export = re.search(r'\bexport\s*\{[^}]*\bas\s+default\b', content)
+        if not named_export:
+            return None
+        named_m = re.search(r'\bexport\s*\{\s*(\w+)\s+as\s+default\b', content)
+        if not named_m:
+            return None
+        class_name = named_m.group(1)
+        m = re.search(
+            rf'class\s+{re.escape(class_name)}\b[^{{]*\bextends\s+(\w+)\.',
+            content,
+        )
+        if not m:
+            return None
     namespace = m.group(1)
     imp = re.search(
         rf"import\s+\*\s+as\s+{re.escape(namespace)}\s+from\s+['\"](\./[^'\"]+)['\"]",
@@ -104,15 +117,19 @@ def main():
         result("FAIL", "prefs/missing-prefs-method",
                "prefs.js does not define fillPreferencesWindow() or getPreferencesWidget()")
 
-    # Default export check
-    if not re.search(r'\bexport\s+default\s+class\b', content):
+    # Default export check — accept both `export default class` and `export { X as default }`
+    has_default_export = bool(
+        re.search(r'\bexport\s+default\s+class\b', content)
+        or re.search(r'\bexport\s*\{[^}]*\bas\s+default\b', content)
+    )
+    if not has_default_export:
         result("WARN", "prefs/default-export",
                "prefs.js missing 'export default class' — required for GNOME 45+")
     else:
         result("PASS", "prefs/default-export", "prefs.js has default export class")
 
     # Check extends ExtensionPreferences
-    if re.search(r'\bexport\s+default\s+class\b', content):
+    if has_default_export:
         if not re.search(r'\bextends\s+ExtensionPreferences\b', content):
             result("WARN", "prefs/extends-base",
                    "prefs.js default class does not extend ExtensionPreferences — "

--- a/tests/assertions/named-default-export.sh
+++ b/tests/assertions/named-default-export.sh
@@ -1,0 +1,14 @@
+# Named default export false-positive regression tests (issue #283)
+# Verifies that `export { X as default }` is accepted as a valid default export
+# for both R-FILE-07 (extension.js) and R-PREFS-02 (prefs.js).
+# Sourced by run-tests.sh — uses run_lint, assert_output_contains, assert_exit_code, etc.
+
+echo "=== named-default-export ==="
+run_lint "named-default-export@test"
+assert_exit_code "exits with 0 (no blocking issues)" 0
+assert_output_not_contains "no R-FILE-07 false positive for extension.js named export" "lifecycle/default-export.*missing"
+assert_output_contains "extension.js default export passes" "\[PASS\].*lifecycle/default-export"
+assert_output_not_contains "no R-PREFS-02 false positive for prefs.js named export" "prefs/default-export.*missing"
+assert_output_contains "prefs.js default export passes" "\[PASS\].*prefs/default-export"
+assert_output_contains "prefs.js extends check runs and passes" "\[PASS\].*prefs/extends-base"
+echo ""

--- a/tests/fixtures/named-default-export@test/extension.js
+++ b/tests/fixtures/named-default-export@test/extension.js
@@ -1,0 +1,14 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// TypeScript and bundlers often emit this form instead of `export default class`
+class MyExtension extends Extension {
+    enable() {
+        this._settings = this.getSettings();
+    }
+
+    disable() {
+        this._settings = null;
+    }
+}
+
+export { MyExtension as default };

--- a/tests/fixtures/named-default-export@test/metadata.json
+++ b/tests/fixtures/named-default-export@test/metadata.json
@@ -1,0 +1,1 @@
+{"uuid": "named-default-export@test", "name": "Named Default Export Test", "description": "Tests that export { X as default } is accepted as a valid default export (R-FILE-07, R-PREFS-02)", "shell-version": ["45", "46", "47", "48"], "url": "https://github.com/test/named-default-export"}

--- a/tests/fixtures/named-default-export@test/prefs.js
+++ b/tests/fixtures/named-default-export@test/prefs.js
@@ -1,0 +1,12 @@
+import Adw from 'gi://Adw';
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+// TypeScript and bundlers often emit this form instead of `export default class`
+class MyPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const page = new Adw.PreferencesPage();
+        window.add(page);
+    }
+}
+
+export { MyPreferences as default };


### PR DESCRIPTION
## Bug

`export { MyClass as default }` is semantically equivalent to `export default class MyClass` but was flagged as a missing default export by both R-FILE-07 (extension.js) and R-PREFS-02 (prefs.js). TypeScript and bundlers (esbuild, rollup) commonly generate the re-export form, making this a real-world false positive for compiled extensions.

Fixes #283.

## Fix

Augmented the detection in both `check-lifecycle.py` and `check-prefs.py` to accept either form:

- **`export default class`** — existing behaviour, unchanged
- **`export { SomeName as default }`** — new: detected via `r'\bexport\s*\{[^}]*\bas\s+default\b'`

Specific changes:

- `check_default_export` in `check-lifecycle.py` (R-FILE-07): now emits PASS for the named re-export form
- Default export + `extends ExtensionPreferences` checks in `check-prefs.py` (R-PREFS-02): both use the combined predicate
- Both `_resolve_local_parent_content` functions: handle `export { X as default }` by extracting the exported name and locating its `class X` definition separately, preserving the local-parent-class fallback for `enable()`/`disable()` and prefs method resolution

## Test

New fixture `named-default-export@test`:

- `extension.js` — uses `class MyExtension extends Extension { … }` + `export { MyExtension as default }`
- `prefs.js` — uses `class MyPreferences extends ExtensionPreferences { … }` + `export { MyPreferences as default }`

New assertion file `tests/assertions/named-default-export.sh` verifies:

- No R-FILE-07 false positive (`lifecycle/default-export` does **not** emit a warning)
- `lifecycle/default-export` emits PASS
- No R-PREFS-02 false positive (`prefs/default-export` does **not** emit a warning)
- `prefs/default-export` emits PASS
- `prefs/extends-base` check runs and emits PASS (extends guard also honours the new form)

Verified by running both scripts directly against the fixture:

```
PASS|lifecycle/default-export|extension.js has default export class
PASS|prefs/default-export|prefs.js has default export class
PASS|prefs/extends-base|prefs.js extends ExtensionPreferences
```

No regressions on existing clean fixtures (`lifecycle-clean@test`, `prefs-constructor-clean@test`).