### PR TITLE
docs(ego-field-test): add test mode field to template and lesson #19 on EGO ZIP vs source divergence

### DIFF
--- a/docs/internal/README.md
+++ b/docs/internal/README.md
@@ -57,6 +57,10 @@ Patterns discovered across field tests — encode here so future rules avoid rep
 17. **Single long lines ≠ minification**: Compiled TypeScript may have one or two very long lines (keyboard constant chains, export lists) in otherwise readable files. The minified-js check now requires 3+ lines > 500 chars.
 18. **Compiled TypeScript (esbuild) generates systematic WARN noise**: `var` declarations from `__defProp`/`__publicField` helpers (R-DEPR-09), verbose parameter names (R-SLOP-38), and many small classes without `destroy()` methods (resource-tracking/no-destroy-method). These are build artifacts, not author issues.
 
+*Test mode differences:*
+
+19. **EGO ZIP and source checkout produce incomparable check and warning counts**: The same extension can yield 153 checks/5 WARNs via EGO ZIP versus 235 checks/22 WARNs via source checkout (observed: Apps Menu v74). Three causes: (a) source repos include `metadata.json.in` templates, multi-extension sub-directories, and locale/build artifacts; (b) directory-name checks always FP on source checkouts (lesson #2); (c) source `main` may differ from the packaged EGO release. **Always record test mode in the Pre-flight section; never compare raw numbers across modes.** EGO ZIP is the canonical mode for calibration against EGO reviewer expectations; source checkout is useful for early-development coverage at the cost of more noise.
+
 ## Other Artifacts
 
 - `false-positive-analysis-2026-02-27.md` — Detailed root-cause analysis for initial false positives (archived; see field-test-hara-hachi-bu.md F-001–F-005)

--- a/docs/internal/field-test-template.md
+++ b/docs/internal/field-test-template.md
@@ -8,6 +8,9 @@ Use this template when running the ego-submit pipeline against a real extension.
 
 - **Extension**: [name] ([UUID])
 - **Source**: [GitHub URL or local path]
+- **Test mode**: `EGO ZIP` | `source checkout`
+  - **EGO ZIP**: Downloaded from extensions.gnome.org (packaged release). Canonical test — matches exactly what EGO reviewers see. Fewer files, cleaner metadata, no build artifacts. Use for calibration against reviewer expectations.
+  - **Source checkout**: Cloned from the extension's Git repository. Exercises more surface area (templates, sub-dirs, build artifacts, locale files). Warning and check counts can be significantly higher — **do not compare raw numbers between the two modes**. Directory-name checks always produce FPs on source checkouts (see lesson #2 in README).
 - **GNOME versions**: [shell-version from metadata.json]
 - **File count**: [N JS files, total lines]
 - **License**: [type and filename]


### PR DESCRIPTION
## Problem

Field tests against the same extension using different test modes produce incomparable numbers, but the existing documentation didn't call this out. Discovered when Apps Menu was tested twice:

| Mode | Checks | WARNs | FAILs |
|------|--------|-------|-------|
| EGO ZIP (v74, from extensions.gnome.org) | 153 | 5 | 0 |
| Source checkout (GitLab `gnome-shell-extensions` main) | 235 | 22 | 0 |

Same extension, same linter version (v0.1.29), 53% more checks and 340% more warnings in source mode.

## Root Causes

1. Source repos include `metadata.json.in` templates, multi-extension sub-directories, locale files, and build artifacts — absent in packaged ZIPs.
2. Directory-name checks always FP on source checkouts (the directory is the repo name, not the UUID path — see lesson #2).
3. Source `main` may be ahead of or behind the EGO packaged release.

## Fix

- **`docs/internal/field-test-template.md`**: Added a `Test mode` field between `Source` and `GNOME versions` with inline guidance on when to use each mode.
- **`docs/internal/README.md`**: Added calibration lesson #19 under a new `Test mode differences:` subsection explaining the three causes with concrete numbers and the rule: always record test mode, never compare raw numbers across modes.