### PR TITLE
fix(ego-lint): suppress R-VER44-01/02 when Meta is aliased to a non-Meta GI namespace

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -837,6 +837,7 @@
   fix: "Use global.compositor.get_laters().addLater(Meta.LaterType.BEFORE_REDRAW, callback)"
   min-version: 44
   replacement-pattern: "get_laters"
+  require-namespace: "Meta"
   compat-downgrade: true
 
 - id: R-VER44-02
@@ -850,6 +851,7 @@
   guard-pattern: "if\\s*\\(\\s*global\\.compositor\\s*\\)"
   guard-window: 7
   replacement-pattern: "get_laters"
+  require-namespace: "Meta"
   compat-downgrade: true
 
 - id: R-VER46-01

--- a/skills/ego-lint/scripts/apply-patterns.py
+++ b/skills/ego-lint/scripts/apply-patterns.py
@@ -349,6 +349,60 @@ def _discover_dev_tool_dirs(ext_dir):
     return dev_dirs, dev_trigger_files
 
 
+def _identifier_namespace_aliased(identifier, file_content):
+    """Return True if `identifier` is provably bound to a non-`identifier` GI namespace.
+
+    Detects patterns like:
+      const { GdkPixbuf: Meta } = imports.gi;   → Meta aliased to GdkPixbuf → True
+      import Meta from 'gi://Clutter';           → Meta aliased to Clutter → True
+      import Meta from 'gi://Meta';              → correct binding → False
+      const { Meta } = imports.gi;              → correct binding → False
+      (no binding found)                         → False (conservative)
+    """
+    # ESM: import Meta from 'gi://Something'
+    esm_re = re.compile(
+        r'^\s*import\s+(?:\*\s+as\s+)?' + re.escape(identifier) +
+        r'\s+from\s+[\'"]gi://(\w+)[\'"]',
+        re.MULTILINE,
+    )
+    m = esm_re.search(file_content)
+    if m:
+        bound_ns = m.group(1)
+        return bound_ns != identifier
+
+    # CJS destructuring: const { ..., Something: Meta, ... } = imports.gi
+    cjs_destr_re = re.compile(
+        r'(?:const|let|var)\s*\{[^}]+\}\s*=\s*imports\.gi\b'
+    )
+    for destr_m in cjs_destr_re.finditer(file_content):
+        block = destr_m.group(0)
+        # Aliasing: SomeThing: identifier  (bound to SomeThing, not identifier)
+        alias_re = re.compile(r'\b(\w+)\s*:\s*' + re.escape(identifier) + r'\b')
+        alias_m = alias_re.search(block)
+        if alias_m:
+            aliased_from = alias_m.group(1)
+            if aliased_from != identifier:
+                return True  # e.g. GdkPixbuf: Meta
+        # Unaliased: identifier appears directly → correct binding
+        unaliased_re = re.compile(
+            r'(?<![:\w])' + re.escape(identifier) + r'(?!\s*:)(?!\w)'
+        )
+        if unaliased_re.search(block):
+            return False  # const { Meta } = imports.gi → correct
+
+    # CJS direct: const Meta = imports.gi.SomeThing
+    direct_re = re.compile(
+        r'(?:const|let|var)\s+' + re.escape(identifier) +
+        r'\s*=\s*imports\.gi\.(\w+)'
+    )
+    m = direct_re.search(file_content)
+    if m:
+        bound_ns = m.group(1)
+        return bound_ns != identifier
+
+    return False  # conservative: no aliasing detected
+
+
 def _is_subprocess_entry(filepath, scan_lines=2):
     """Return True if the file is a standalone GJS subprocess (has #!/usr/bin/env gjs shebang)."""
     try:
@@ -547,6 +601,16 @@ def main():
                     replacement = rule.get('replacement-pattern', '')
                     if replacement and replacement in file_content:
                         continue
+
+                    # require-namespace: if set, check that the leading identifier
+                    # in the pattern is actually bound to the expected GI namespace.
+                    # Suppresses FPs where an unrelated module is aliased to the name.
+                    require_ns = rule.get('require-namespace', '')
+                    if require_ns:
+                        # Extract identifier: '\bMeta\.' → 'Meta'
+                        id_match = re.match(r'\\b(\w+)\\\.', pattern)
+                        if id_match and _identifier_namespace_aliased(id_match.group(1), file_content):
+                            continue
 
                     skip_comments = rule.get('skip-comments', '') == 'true'
                     in_block_comment = False

--- a/tests/assertions/version-compat.sh
+++ b/tests/assertions/version-compat.sh
@@ -42,3 +42,11 @@ run_lint "gsettings-bind-flags@test"
 assert_exit_code "exits with 0 (advisory only)" 0
 assert_output_contains "warns on GObject.BindingFlags" "\[WARN\].*R-QUAL-23"
 echo ""
+
+# --- meta-alias-no-ver44 ---
+echo "=== meta-alias-no-ver44 ==="
+run_lint "meta-alias-no-ver44@test"
+assert_exit_code "exits with 0 (FP suppressed)" 0
+assert_output_not_contains "R-VER44-01 must not fire on GdkPixbuf alias" "\[FAIL\].*R-VER44-01"
+assert_output_not_contains "R-VER44-02 must not fire on GdkPixbuf alias" "\[FAIL\].*R-VER44-02"
+echo ""

--- a/tests/fixtures/meta-alias-no-ver44@test/extension.js
+++ b/tests/fixtures/meta-alias-no-ver44@test/extension.js
@@ -1,0 +1,15 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+// GdkPixbuf aliased as Meta (as in AppIndicator promiseUtils.js)
+import GdkPixbuf from 'gi://GdkPixbuf';
+const { GLib, Gio, GObject, GdkPixbuf: Meta } = imports.gi;
+
+export default class TestExtension extends Extension {
+    enable() {
+        // Meta here is GdkPixbuf — R-VER44-01 should NOT fire
+        const pixbuf = Meta.new_from_file('icon.png');
+        Meta.later_add(1, () => {});
+    }
+
+    disable() {}
+}

--- a/tests/fixtures/meta-alias-no-ver44@test/metadata.json
+++ b/tests/fixtures/meta-alias-no-ver44@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "meta-alias-no-ver44@test",
+    "name": "Meta Alias No R-VER44 Test",
+    "description": "GdkPixbuf aliased to Meta — R-VER44-01/02 should not fire",
+    "shell-version": ["45", "48"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

R-VER44-01/02 fire on \`Meta.later_add()\`/\`Meta.later_remove()\` without verifying that the local identifier \`Meta\` is actually imported from \`gi://Meta\`. When an extension aliases a different GI namespace to the name \`Meta\` (e.g. \`const { GdkPixbuf: Meta } = imports.gi\` as in AppIndicator's \`promiseUtils.js\`), the check fires on the aliased name — a false FAIL.

**Repro (AppIndicator):**
\`\`\`js
const { GLib, Gio, GObject, GdkPixbuf: Meta } = imports.gi;
// ...
Meta.later_add(1, () => {});  // R-VER44-01 fires — wrong! Meta is GdkPixbuf here
\`\`\`

## Fix

Add a \`require-namespace\` field to R-VER44-01/02 (value: \`"Meta"\`). When set, \`apply-patterns.py\` calls the new \`_identifier_namespace_aliased()\` helper before flagging a file. The helper scans import declarations for:

- ESM: \`import Meta from 'gi://SomethingElse'\` → aliased → suppress
- CJS destructuring: \`const { GdkPixbuf: Meta } = imports.gi\` → aliased → suppress
- CJS direct: \`const Meta = imports.gi.SomethingElse\` → aliased → suppress
- Correct binding or no binding found → proceed (conservative)

The check is file-scoped and suppresses the entire file when aliasing is confirmed, consistent with \`replacement-pattern\` and other file-level guards. \`require-namespace\` is a generic field reusable on other identifier-based patterns.

## Test Results

\`\`\`
=== meta-alias-no-ver44 ===
  ✓ exits with 0 (FP suppressed)
  ✓ R-VER44-01 must not fire on GdkPixbuf alias
  ✓ R-VER44-02 must not fire on GdkPixbuf alias
\`\`\`

555 passed (+3), 259 failed (unchanged baseline) — no regressions.

Closes #282.