### PR TITLE
fix(ego-lint): suppress R-SLOP-24 when schema_id is a variable identifier

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -704,7 +704,7 @@
   message: "new Gio.Settings() is incorrect in GNOME 45+; use this.getSettings() from Extension base class"
   category: ai-slop
   fix: "Use this.getSettings() in Extension subclass or this.getSettings() in ExtensionPreferences"
-  guard-pattern: "schema.*org\\.gnome\\.(?!shell\\.extensions\\.)|['\"]desktop\\.|shell\\.app-switcher|(?:KEYBINDINGS|NOTIFICATIONS|DESKTOP|INTERFACE|WM|MUTTER|APP_SWITCHER)_SCHEMA"
+  guard-pattern: "schema.*org\\.gnome\\.(?!shell\\.extensions\\.)|['\"]desktop\\.|shell\\.app-switcher|(?:KEYBINDINGS|NOTIFICATIONS|DESKTOP|INTERFACE|WM|MUTTER|APP_SWITCHER)_SCHEMA|schema_id\\s*:\\s*[a-zA-Z_$]"
   guard-window-forward: 5
   exclude-dirs: ["service"]
 

--- a/tests/assertions/dash-to-panel-fixes.sh
+++ b/tests/assertions/dash-to-panel-fixes.sh
@@ -59,3 +59,9 @@ assert_output_not_contains "R-SLOP-24 suppressed for NOTIFICATIONS_SCHEMA consta
 assert_output_not_contains "R-SLOP-24 suppressed for shell.app-switcher" "\[WARN\].*R-SLOP-24.*app-switcher"
 assert_output_contains "R-SLOP-24 still fires for extension-owned schema" "\[WARN\].*R-SLOP-24"
 echo ""
+
+# --- dynamic-schema-id (R-SLOP-24 guard for variable schema_id) ---
+echo "=== dynamic-schema-id ==="
+run_lint "dynamic-schema-id@test"
+assert_output_not_contains "R-SLOP-24 suppressed for variable schema_id in loop" "\[WARN\].*R-SLOP-24"
+echo ""

--- a/tests/fixtures/dynamic-schema-id@test/extension.js
+++ b/tests/fixtures/dynamic-schema-id@test/extension.js
@@ -1,0 +1,24 @@
+import Gio from 'gi://Gio';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+export default class DynamicSchemaIdExtension extends Extension {
+    enable() {
+        // Dynamic variable as schema_id — should NOT trigger R-SLOP-24
+        // (reading arbitrary schemas from other sources, e.g. settings migration)
+        for (const schemaId of this._externalSchemas) {
+            const settings = new Gio.Settings({ schema_id: schemaId });
+            this._cache.set(schemaId, settings);
+        }
+
+        // Function parameter as schema_id — should NOT trigger R-SLOP-24
+        this._loadSettings(this._schemaId);
+    }
+
+    _loadSettings(id) {
+        return new Gio.Settings({ schema_id: id });
+    }
+
+    disable() {
+        this._cache = null;
+    }
+}

--- a/tests/fixtures/dynamic-schema-id@test/metadata.json
+++ b/tests/fixtures/dynamic-schema-id@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "dynamic-schema-id@test",
+    "name": "Dynamic Schema ID Test",
+    "description": "Tests R-SLOP-24 guard suppression when schema_id is a variable identifier (not a string literal)",
+    "shell-version": ["48"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

R-SLOP-24 fires on `new Gio.Settings({ schema_id: schemaId })` where `schemaId` is a variable reference, not a string literal. The existing `guard-pattern` only suppresses known string patterns (system schemas, keybinding schema constants). When the argument is an identifier, no string match can succeed — the check fires unconditionally.

**Repro (from Tiling Assistant `extension.js`):**
```js
for (const schemaId of this._originalSettings.keys()) {
    const settings = new Gio.Settings({ schema_id: schemaId });  // WARN R-SLOP-24 — FP
}
```

This is a settings restore/migration pattern. The extension is iterating over schemas from other sources and cannot use `this.getSettings()`, which only reads the extension's own schema.

## Fix

Extend `guard-pattern` in R-SLOP-24 with:
```
schema_id\s*:\s*[a-zA-Z_$]
```

This suppresses the warning when `schema_id:` is followed by an identifier (variable, parameter, property access start) rather than a string literal. String literals still fall through to the existing guard checks.

## Test

New fixture `dynamic-schema-id@test` exercises the pattern with:
- A loop variable (`schema_id: schemaId`) — should not warn
- A method parameter (`schema_id: id`) — should not warn

Assertion added to `dash-to-panel-fixes.sh`.

Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)