### PR TITLE
feat(ego-lint): promote GNOME 51 to CURRENT_STABLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Extension: /path/to/my-extension@username
 | **Security** | Subprocess validation, pkexec targets, clipboard/network disclosure, `/tmp` writes, telemetry, curl/gsettings spawn |
 | **Deprecated** | Mainloop, Lang, ByteArray, ExtensionUtils, Tweener, legacy `imports.*` syntax |
 | **Web APIs** | setTimeout, setInterval, fetch, XMLHttpRequest, WebSocket, localStorage |
-| **Version Compat** | GNOME 44–50 migration rules (version-gated, only fire for declared shell-versions) |
+| **Version Compat** | GNOME 44–51 migration rules (version-gated, only fire for declared shell-versions) |
 | **CSS** | Unscoped class names, `!important` usage, GNOME Shell theme class overrides |
 | **Code Quality** | AI slop detection (try-catch density, impossible states, empty catches, obfuscation, code provenance scoring) |
 | **Package** | Forbidden files in zip, required files, compiled schemas for GNOME 45+ |

--- a/skills/ego-lint/scripts/check-metadata.py
+++ b/skills/ego-lint/scripts/check-metadata.py
@@ -203,10 +203,10 @@ def main():
         if isinstance(sv, list):
             result("PASS", "metadata/shell-version-array", "shell-version is an array")
 
-            if "50" in sv:
-                result("PASS", "metadata/shell-version-current", "shell-version includes current GNOME 50")
+            if "51" in sv:
+                result("PASS", "metadata/shell-version-current", "shell-version includes current GNOME 51")
             else:
-                result("WARN", "metadata/shell-version-current", "shell-version does not include GNOME 50")
+                result("WARN", "metadata/shell-version-current", "shell-version does not include GNOME 51")
         else:
             result("FAIL", "metadata/shell-version-array", f"shell-version must be an array, got {type(sv).__name__}")
 
@@ -330,7 +330,7 @@ def check_gnome_trademark(meta):
                "No GNOME trademark violations in metadata")
 
 
-CURRENT_STABLE = 50
+CURRENT_STABLE = 51
 
 
 def check_url_field(meta):


### PR DESCRIPTION
## Summary

Promotes GNOME 51 to `CURRENT_STABLE` in the ego-lint checker.

- `CURRENT_STABLE = 50` → `CURRENT_STABLE = 51`
- `shell-version-current` checks now reference GNOME 51 (extensions not declaring `"51"` in `shell-version` get a WARN)
- README version compat row updated: GNOME 44–50 → 44–51

## ⏰ Time-gated — Do NOT merge before 2026-09-16

GNOME 51 final ships **September 16, 2026**. Merging this earlier would cause false WARNs on all extensions that correctly target only the current stable (50).

**Merge order:**
1. PR #292 (`feat/gnome-51-version-support`) — un-draft and merge ~June 27 when Alpha ships (adds `"51"` to `VALID_GNOME_VERSIONS`)
2. **This PR** — un-draft and merge September 16 (promotes 51 to `CURRENT_STABLE`)

## Test Results

- Python unit tests: 55 passed, 1 skipped
- 259 fixture-test failures pre-exist on `main` and are unrelated to this change