### PR TITLE
fix(ego-lint): suppress R-VER47-01 in else-branch of shellVersionIsAtLeast(47) guard

### DIFF
--- a/rules/patterns.yaml
+++ b/rules/patterns.yaml
@@ -944,7 +944,9 @@
   category: version-compat
   fix: "Import Cogl from 'gi://Cogl' and use new Cogl.Color() instead"
   min-version: 47
-  guard-pattern: "Clutter\\.Color\\s*\\?"
+  skip-comments: true
+  guard-pattern: "Clutter\\.Color\\s*\\?|shellVersionIsAtLeast\\s*\\(\\s*47"
+  guard-window: 8
   compat-downgrade: true
 
 # --- GNOME 48 migration (version-gated) ---

--- a/tests/assertions/version-guard-patterns.sh
+++ b/tests/assertions/version-guard-patterns.sh
@@ -8,6 +8,12 @@ assert_output_not_contains "no FAIL for R-VER49-02 with fallback guard" "\[FAIL\
 assert_output_not_contains "no FAIL for R-VER47-01 with ternary guard" "\[FAIL\].*R-VER47-01"
 echo ""
 
+echo "=== version-guard-shellversion47 ==="
+run_lint "version-guard-shellversion47@test"
+assert_exit_code "exits with 0 (shellVersionIsAtLeast guard suppressed)" 0
+assert_output_not_contains "no WARN for R-VER47-01 in else-branch of shellVersionIsAtLeast(47)" "\[WARN\].*R-VER47-01"
+echo ""
+
 echo "=== version-guard-boolean ==="
 run_lint "version-guard-boolean@test"
 assert_exit_code "exits with 0 (all version guards suppressed)" 0

--- a/tests/fixtures/version-guard-shellversion47@test/extension.js
+++ b/tests/fixtures/version-guard-shellversion47@test/extension.js
@@ -1,0 +1,26 @@
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import Clutter from 'gi://Clutter';
+import Cogl from 'gi://Cogl';
+import {shellVersionIsAtLeast} from 'resource:///org/gnome/shell/misc/util.js';
+
+// Cross-version color API: the canonical migration pattern for GNOME 47
+// Clutter.Color in the else-branch is valid — it only runs on GNOME < 47
+export function parseColor(string) {
+    let color;
+    if (shellVersionIsAtLeast(47, 'alpha')) {
+        color = Cogl.Color.from_string(string)[1];
+    } else {
+        color = Clutter.Color.from_string(string)[1];
+    }
+    return color;
+}
+
+export default class VersionGuard47Extension extends Extension {
+    enable() {
+        this._color = parseColor('#ff0000');
+    }
+
+    disable() {
+        this._color = null;
+    }
+}

--- a/tests/fixtures/version-guard-shellversion47@test/metadata.json
+++ b/tests/fixtures/version-guard-shellversion47@test/metadata.json
@@ -1,0 +1,7 @@
+{
+    "uuid": "version-guard-shellversion47@test",
+    "name": "Version Guard shellVersionIsAtLeast 47 Test",
+    "description": "Tests R-VER47-01 suppression when Clutter.Color is in else-branch of shellVersionIsAtLeast(47) guard",
+    "shell-version": ["46", "47"],
+    "url": "https://example.com"
+}


### PR DESCRIPTION
## Problem

R-VER47-01 warns when `Clutter.Color` is used without a GNOME ≥47 version guard, because GNOME 47 moved the class to `Cogl.Color`. However, the rule fires a false positive when `Clutter.Color` appears in the **else-branch** of an `if (shellVersionIsAtLeast(47, ...))` block — the canonical cross-version migration pattern:

```js
if (shellVersionIsAtLeast(47, 'alpha')) {
    // modern path — Cogl.Color
} else {
    // legacy path — Clutter.Color still correct here
    const c = new Clutter.Color({ red: 255 });
}
```

Discovered during field test of Burn My Windows v48.

Fixes #294

## Fix

- Extended `guard-pattern` for R-VER47-01 to also match `shellVersionIsAtLeast\(47` (in addition to the existing ternary guard `Clutter\.Color\s*\?`)
- Set `guard-window: 8` to look back through the else-body to the version check line
- Added `skip-comments: true` to avoid firing on comment-only mentions

## Test

New fixture `tests/fixtures/version-guard-shellversion47@test/` with the real-world else-branch pattern. New assertion in `tests/assertions/version-guard-patterns.sh` confirming no WARN fires.

## Verification

```
✓ New fixture PASS (no R-VER47-01 WARN in else-branch)
✓ Existing gnome47-compat@test still FAILs on unguarded Clutter.Color
✓ rules/patterns.yaml validates (123 rules clean)
✓ 559 tests pass (+1 from baseline of 558)
```